### PR TITLE
[11.0][FIX] get partner data raise warning

### DIFF
--- a/l10n_ro_partner_create_by_vat/models/res_partner.py
+++ b/l10n_ro_partner_create_by_vat/models/res_partner.py
@@ -187,13 +187,7 @@ class ResPartner(models.Model):
                 if not result or not result.get("date_generale"):
                     anaf_error = _("Anaf didn't find any company with VAT=%s !") % cod
         else:
-            anaf_error = _(
-                "Anaf request error: \nresponse=%(response)s "
-                "\nreason=%(reason)s \ntext=%(text)s",
-                response=res,
-                reason=res.reason,
-                text=res.text,
-            )
+            raise Warning(_("Anaf request error: \nresponse=%s \nreason=%s \ntext=%s" % (res, res.reason, res.text)))
         return anaf_error, result
 
     @api.model


### PR DESCRIPTION
button_get_partner_data() care apeleaza _get_Anaf() nu foloseste anaf_error, asa ca userul nu vede de ce nu se preiau datele. 
acum anaf_error() arunca Warning daca response_code e diferit de 200 sau content-type nu este "application/json"
utilizatorul vede motivul pentru care anaf nu a returnat nimic, in cazul de mai jos: "Mentenanta sistem"
![image](https://github.com/dhongu/l10n-romania/assets/15253112/de58d251-eea9-4f01-9522-d3f8806529b2)
