### PR TITLE
[16.0][UPD] Get partner data display feedback when ANAF error

### DIFF
--- a/l10n_ro_partner_create_by_vat_button/i18n/ro.po
+++ b/l10n_ro_partner_create_by_vat_button/i18n/ro.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_partner_create_by_vat_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-03-02 11:51+0000\n"
+"PO-Revision-Date: 2024-03-02 11:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_partner_create_by_vat_button
+#. odoo-python
+#: code:addons/l10n_ro_partner_create_by_vat_button/models/res_partner.py:0
+#, python-format
+msgid ""
+"ANAF Webservice not working.\n"
+"Please try again until it works"
+msgstr ""
+"Serviciul web ANAF nu funcționează.\n"
+"Te rog încearcă din nou până când vei primi datele."
+
+#. module: l10n_ro_partner_create_by_vat_button
+#: model:ir.model,name:l10n_ro_partner_create_by_vat_button.model_res_partner
+msgid "Contact"
+msgstr "Contact"
+
+#. module: l10n_ro_partner_create_by_vat_button
+#: model_terms:ir.ui.view,arch_db:l10n_ro_partner_create_by_vat_button.view_partner_form
+msgid "Get Partner Data"
+msgstr "Preia date partener"

--- a/l10n_ro_partner_create_by_vat_button/models/res_partner.py
+++ b/l10n_ro_partner_create_by_vat_button/models/res_partner.py
@@ -5,7 +5,8 @@
 
 import logging
 
-from odoo import api, models
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -41,5 +42,7 @@ class ResPartner(models.Model):
     def button_get_partner_data(self):
         if self.name and not self.vat:
             self.vat = self.name
-        self.ro_vat_change()
+        res = self.ro_vat_change()
+        if "warning" in res:
+            raise ValidationError(_("ANAF Webservice not working.\nPlease try again until it works."))
         # self.onchange_vat_subjected()  # fortare compltare ro


### PR DESCRIPTION
Endpoint-ul ANAF raspunde random cu un mesaj de "Mentenanta sistem", desi daca faci din nou request-ul, functioneaza. Poate ar fi bine ca odoo sa afiseze user-ului faptul ca datele nu au fost preluate si sa-l indrume sa apese din nou butonul de preluare.
Adaugare i18n