### PR TITLE
[17.0][FIX] cash register: fix move document_type

### DIFF
--- a/l10n_ro_cash_register/__manifest__.py
+++ b/l10n_ro_cash_register/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Cash Register",
-    "version": "17.0.1.1.0",
+    "version": "17.0.1.1.1",
     "author": "Terrabit," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "category": "Localization",

--- a/l10n_ro_cash_register/wizard/cash_register_operation.py
+++ b/l10n_ro_cash_register/wizard/cash_register_operation.py
@@ -55,5 +55,6 @@ class CashRegisterOperation(models.TransientModel):
                 ),
             ],
         }
-        move = self.env["account.move"].with_context(default_l10n_ro_cash_document_type="other").create(value)
+        move = self.env["account.move"].create(value)
+        move.write({"l10n_ro_cash_document_type": "other"})
         move._post()


### PR DESCRIPTION
explicitly write document_type in move, at creation time always sets it to False since is related to a payment which doesn't exist