### PR TITLE
[18.0][FIX] Fixing etransport batch to make de check working and adding a condition for the ones with internal, mrp_operation as operation type

### DIFF
--- a/l10n_ro_etransport_batch_enhancement/models/__init__.py
+++ b/l10n_ro_etransport_batch_enhancement/models/__init__.py
@@ -4,3 +4,4 @@
 
 
 from . import stock_picking_batch
+from . import stock_picking

--- a/l10n_ro_etransport_batch_enhancement/models/stock_picking.py
+++ b/l10n_ro_etransport_batch_enhancement/models/stock_picking.py
@@ -1,0 +1,11 @@
+from odoo import models, fields, _, api
+
+class Picking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.model
+    def _l10n_ro_edi_stock_validate_carrier_filter(self, picking):
+        validate_carrier = self.env.context.get('l10n_ro_edi_stock_validate_carrier', False)
+        if picking.picking_type_id.code in ['internal', 'mrp_operation']:
+            validate_carrier = False
+        return picking.company_id.account_fiscal_country_id.code == 'RO' and (picking.l10n_ro_edi_stock_enable or validate_carrier)

--- a/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
+++ b/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
@@ -3,6 +3,8 @@
 # See README.rst file on addons root folder for license details
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
 from odoo.addons.stock_picking_batch.models.stock_picking_batch import StockPickingBatch as BaseBatch
 
 
@@ -78,23 +80,24 @@ class StockPickingBatch(models.Model):
 
         return errors
 
-    #monkey patching action_done
+    # monkey patching action_done
     def action_done(self):
-        # EXTENDS 'stock_picking_batch'
         self.ensure_one()
         self._check_company()
 
         self.picking_ids.with_context(l10n_ro_edi_stock_validate_carrier=True)._l10n_ro_edi_stock_validate_carrier()
-    
+
         if self.l10n_ro_edi_stock_required:
             # Carrier should be the same on all pickings
             first_carrier = self.picking_ids[0].carrier_id
             if any(picking.carrier_id != first_carrier for picking in self.picking_ids):
                 raise UserError(_("All Pickings in a Batch Transfer should have the same Carrier"))
-    
+
             # Commercial partner should be the same on all pickings
             first_commercial_partner = self.picking_ids[0].partner_id.commercial_partner_id
-            if any(picking.partner_id.commercial_partner_id != first_commercial_partner for picking in self.picking_ids):
+            if any(
+                picking.partner_id.commercial_partner_id != first_commercial_partner for picking in self.picking_ids
+            ):
                 raise UserError(_("All Pickings in a Batch Transfer should have the same Commercial Partner"))
 
         return BaseBatch.action_done(self)

--- a/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
+++ b/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
@@ -3,6 +3,7 @@
 # See README.rst file on addons root folder for license details
 
 from odoo import _, api, fields, models
+from odoo.addons.stock_picking_batch.models.stock_picking_batch import StockPickingBatch as BaseBatch
 
 
 class StockPickingBatch(models.Model):
@@ -76,3 +77,24 @@ class StockPickingBatch(models.Model):
                 errors.remove(error)
 
         return errors
+
+    #monkey patching action_done
+    def action_done(self):
+        # EXTENDS 'stock_picking_batch'
+        self.ensure_one()
+        self._check_company()
+
+        self.picking_ids.with_context(l10n_ro_edi_stock_validate_carrier=True)._l10n_ro_edi_stock_validate_carrier()
+    
+        if self.l10n_ro_edi_stock_required:
+            # Carrier should be the same on all pickings
+            first_carrier = self.picking_ids[0].carrier_id
+            if any(picking.carrier_id != first_carrier for picking in self.picking_ids):
+                raise UserError(_("All Pickings in a Batch Transfer should have the same Carrier"))
+    
+            # Commercial partner should be the same on all pickings
+            first_commercial_partner = self.picking_ids[0].partner_id.commercial_partner_id
+            if any(picking.partner_id.commercial_partner_id != first_commercial_partner for picking in self.picking_ids):
+                raise UserError(_("All Pickings in a Batch Transfer should have the same Commercial Partner"))
+
+        return BaseBatch.action_done(self)


### PR DESCRIPTION
**Problema:** 
    Bifa de etransport required este nefunctionala.
**Cauza:** 
    Pentru batch Odoo trimite un context care spune sa se faca etransport. Acesta este mereu True in cazul la batch.
**Solutie:** 
    In functia care filtreaza transferurile pe care sa se aplice procesul de etransport am adaugat o conditie care deriva fluxul pentru transferurile cu tip de operatie intern si care tin de productie. Pentru aceste 2 tipuri nu vom face etransport niciodata, dar pentru restul transferurilor se va merge mereu pe etransport cand bifa este true sau false, asa cum merge standardul Odoo. 
    Aici a mai fost nevoie sa fac un mokey patch pe functia de action_done de pe batch. Motivul: si daca trebuia sa se faca etransport sau nu tot se faceau validarile de carrier, lucru pe care trebuie sa il controlam prin bifa. Monkey patchul a fost facut pentru ca nu puteau sa suprascriu normal si dupa sa apelez cu super, pentru ca tot se executa suprascrierea din l10n_ro_edi_stock_batch. Astfel eu sar peste acea suprascriere si nu o mai folosesc niciodata.
