### PR TITLE
[FIX] l10n_ro_invoice_report: migrate payment_bank_id to company-dependent storage

### DIFF
--- a/l10n_ro_invoice_report/__manifest__.py
+++ b/l10n_ro_invoice_report/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Romania - Invoice Report Terrabit",
     "summary": "Localizare Terrabit - Facturi, Chitanta",
-    "version": "19.0.3.4.16",
+    "version": "19.0.3.4.17",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "license": "AGPL-3",

--- a/l10n_ro_invoice_report/migrations/19.0.3.4.17/pre-migration.py
+++ b/l10n_ro_invoice_report/migrations/19.0.3.4.17/pre-migration.py
@@ -1,0 +1,76 @@
+# ©  2008-2026 Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Convert res_partner.payment_bank_id to company-dependent storage.
+
+    Older versions stored ``payment_bank_id`` as a regular integer (Many2one)
+    column. The field is now ``company_dependent=True``, which in Odoo 17+ is
+    stored as a jsonb column keyed by company id. PostgreSQL cannot cast
+    integer to jsonb automatically, so the data must be migrated explicitly.
+
+    We rely on the official ``odoo.upgrade.util`` helper when available
+    (Odoo.sh / Enterprise upgrade context) and fall back to a portable SQL
+    migration otherwise (on-premise / plain ``-u`` updates).
+    """
+    cr.execute(
+        """
+        SELECT data_type
+          FROM information_schema.columns
+         WHERE table_name = 'res_partner'
+           AND column_name = 'payment_bank_id'
+        """
+    )
+    row = cr.fetchone()
+    if not row:
+        # Column does not exist yet; Odoo will create it as jsonb.
+        return
+    if row[0] == "jsonb":
+        # Already migrated.
+        return
+
+    _logger.info(
+        "Migrating res_partner.payment_bank_id from %s to company-dependent (jsonb) storage",
+        row[0],
+    )
+
+    try:
+        from odoo.upgrade import util
+    except ImportError:
+        util = None
+
+    if util is not None:
+        util.make_field_company_dependent(
+            cr,
+            "res.partner",
+            "payment_bank_id",
+            "many2one",
+            target_model="res.partner.bank",
+        )
+        return
+
+    # Portable fallback: preserve the existing value for every company.
+    _logger.info("odoo.upgrade.util not available, using SQL fallback")
+    cr.execute("SELECT array_agg(id) FROM res_company")
+    company_ids = cr.fetchone()[0] or []
+
+    cr.execute("ALTER TABLE res_partner RENAME COLUMN payment_bank_id TO payment_bank_id_old")
+    cr.execute("ALTER TABLE res_partner ADD COLUMN payment_bank_id jsonb")
+
+    for company_id in company_ids:
+        cr.execute(
+            """
+            UPDATE res_partner
+               SET payment_bank_id =
+                   COALESCE(payment_bank_id, '{}'::jsonb)
+                   || jsonb_build_object(%s, payment_bank_id_old)
+             WHERE payment_bank_id_old IS NOT NULL
+            """,
+            (str(company_id),),
+        )
+
+    cr.execute("ALTER TABLE res_partner DROP COLUMN payment_bank_id_old")


### PR DESCRIPTION
## Problemă

La update-ul modulului `l10n_ro_invoice_report` pe baze de date existente, încărcarea registry-ului crapă în `_auto_init`:

```
psycopg2.errors.CannotCoerce: cannot cast type integer to jsonb
LINE 1: ... "payment_bank_id" TYPE jsonb USING "payment_bank_id"::jsonb
```

Câmpul `res.partner.payment_bank_id` este `company_dependent=True`. În Odoo 17+ câmpurile company-dependent se stochează ca o coloană `jsonb` (cheile = id-uri de companii). Pe bazele unde coloana exista anterior ca `integer` simplu (Many2one), PostgreSQL nu poate face cast automat `integer → jsonb`.

## Soluție

Adaug un script de **pre-migrare** (`migrations/19.0.3.4.17/pre-migration.py`) care convertește coloana:

- folosește helper-ul oficial `odoo.upgrade.util.make_field_company_dependent` când e disponibil (context upgrade Odoo.sh / Enterprise);
- cade pe o migrare SQL portabilă altfel (on-premise / `-u` simplu), păstrând valoarea existentă pentru fiecare companie;
- idempotent — sare dacă coloana e deja `jsonb`.

Versiunea modulului: `19.0.3.4.16` → `19.0.3.4.17` (ca migrarea să se declanșeze).

Câmpul rămâne `company_dependent=True` (corect pentru multi-company; există test dedicat `test_company_dependent_payment_bank_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)