### PR TITLE
Schimbă statusul modulului în "Production/Stable"

### DIFF
--- a/l10n_ro_stock_age_report/__manifest__.py
+++ b/l10n_ro_stock_age_report/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "Terrabit, NextERP Romania,Dakai Soft,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "depends": ["l10n_ro_stock", "l10n_ro_stock_account"],
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "license": "AGPL-3",
     "data": [
         "wizard/stock_age_report.xml",


### PR DESCRIPTION
Actualizează statusul de dezvoltare din "Beta" în "Production/Stable" în manifest-ul modulului `l10n_ro_stock_age_report`. Această modificare reflectă stabilitatea și pregătirea modulului pentru utilizare în medii de producție.