### PR TITLE
[IMP] l10n_ro_invoice_report: print cash payment receipt on out_receipt

### DIFF
--- a/l10n_ro_invoice_report/__manifest__.py
+++ b/l10n_ro_invoice_report/__manifest__.py
@@ -4,11 +4,12 @@
 {
     "name": "Romania - Invoice Report Terrabit",
     "summary": "Localizare Terrabit - Facturi, Chitanta",
-    "version": "18.0.3.4.27",
+    "version": "18.0.3.4.28",
     "author": "Dorin Hongu," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "license": "AGPL-3",
     "category": "Localization",
+    "development_status": "Mature",
     "countries": ["ro"],
     "depends": [
         "base",

--- a/l10n_ro_invoice_report/i18n/ro.po
+++ b/l10n_ro_invoice_report/i18n/ro.po
@@ -227,6 +227,11 @@ msgid "Cancelled Invoice"
 msgstr "Factura anulata"
 
 #. module: l10n_ro_invoice_report
+#: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.header_invoice
+msgid "Cancelled Sales Receipt"
+msgstr "Chitanță vânzare anulată"
+
+#. module: l10n_ro_invoice_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.l10n_ro_report_invoice_document
 msgid "Coface Logo"
 msgstr ""
@@ -291,6 +296,11 @@ msgstr "Factura storno ciorna"
 #: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.header_invoice
 msgid "Draft Invoice"
 msgstr "Factura ciorna"
+
+#. module: l10n_ro_invoice_report
+#: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.header_invoice
+msgid "Draft Sales Receipt"
+msgstr "Chitanță vânzare ciornă"
 
 #. module: l10n_ro_invoice_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.report_payment
@@ -458,10 +468,20 @@ msgid "Representing counter value of invoice"
 msgstr "Reprezentând contravaloarea facturii"
 
 #. module: l10n_ro_invoice_report
+#: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.l10n_ro_report_invoice_document
+msgid "Representing counter value of sales receipt"
+msgstr "Reprezentând contravaloarea bonului"
+
+#. module: l10n_ro_invoice_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.report_payment
 #: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.report_voucher
 msgid "Representing:"
 msgstr "Reprezentând c/v:"
+
+#. module: l10n_ro_invoice_report
+#: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.header_invoice
+msgid "Sales Receipt"
+msgstr "Chitanță vânzare"
 
 #. module: l10n_ro_invoice_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_invoice_report.view_account_invoice_filter

--- a/l10n_ro_invoice_report/models/__init__.py
+++ b/l10n_ro_invoice_report/models/__init__.py
@@ -1,6 +1,8 @@
 # ©  2008-2023 Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+
+from . import res_company
 from . import res_partner
 from . import account_invoice
 

--- a/l10n_ro_invoice_report/models/account_invoice.py
+++ b/l10n_ro_invoice_report/models/account_invoice.py
@@ -101,6 +101,8 @@ class AccountInvoice(models.Model):
     def is_bf_printed(self):
         """Check if the invoice has been printed with BF (Bon Fiscal)"""
         self.ensure_one()
+        if not self.move_type == "out_invoice":
+            return False
         if hasattr(self, "receipt_print"):
             return self.receipt_print
         return False

--- a/l10n_ro_invoice_report/models/res_company.py
+++ b/l10n_ro_invoice_report/models/res_company.py
@@ -1,0 +1,26 @@
+# ©  2015-2023 Deltatech
+# See README.rst file on addons root folder for license details
+
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    email_on_invoice_address = fields.Boolean(string="Show email", help="Show email on invoice address")
+    phone_on_invoice_address = fields.Boolean(string="Show phone", help="Show phone on invoice address")
+    marker_on_invoice_address = fields.Boolean(string="Show marker", help="Show marker on invoice address")
+    index_line_on_invoice = fields.Boolean(string="Show index line", help="Show index line on invoice")
+    show_total_amount_with_taxes = fields.Boolean(
+        string="Show total amount with taxes", help="Show total amount with taxes"
+    )
+    hide_invoice_payment_communication = fields.Boolean(string="Hide invoice payment communication")
+    hide_pickings_in_invoice = fields.Boolean(string="Hide picking in invoice")
+    remove_product_name_from_invoice_line = fields.Boolean(string="Remove product name from invoice line")
+    show_invoice_delegate = fields.Boolean(string="Show invoice delegate", default=True)
+    show_undiscounted_price_on_invoice = fields.Boolean(string="Show undiscounted price on invoice")
+    show_coface_logo = fields.Boolean(
+        string="Show Coface logo",
+        help="Display the Coface logo on the invoice to indicate that the debt is insured by Coface.",
+    )

--- a/l10n_ro_invoice_report/models/res_config.py
+++ b/l10n_ro_invoice_report/models/res_config.py
@@ -5,27 +5,6 @@
 from odoo import fields, models
 
 
-class ResCompany(models.Model):
-    _inherit = "res.company"
-
-    email_on_invoice_address = fields.Boolean(string="Show email", help="Show email on invoice address")
-    phone_on_invoice_address = fields.Boolean(string="Show phone", help="Show phone on invoice address")
-    marker_on_invoice_address = fields.Boolean(string="Show marker", help="Show marker on invoice address")
-    index_line_on_invoice = fields.Boolean(string="Show index line", help="Show index line on invoice")
-    show_total_amount_with_taxes = fields.Boolean(
-        string="Show total amount with taxes", help="Show total amount with taxes"
-    )
-    hide_invoice_payment_communication = fields.Boolean(string="Hide invoice payment communication")
-    hide_pickings_in_invoice = fields.Boolean(string="Hide picking in invoice")
-    remove_product_name_from_invoice_line = fields.Boolean(string="Remove product name from invoice line")
-    show_invoice_delegate = fields.Boolean(string="Show invoice delegate", default=True)
-    show_undiscounted_price_on_invoice = fields.Boolean(string="Show undiscounted price on invoice")
-    show_coface_logo = fields.Boolean(
-        string="Show Coface logo",
-        help="Display the Coface logo on the invoice to indicate that the debt is insured by Coface.",
-    )
-
-
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 

--- a/l10n_ro_invoice_report/tests/test_invoice_report_basic.py
+++ b/l10n_ro_invoice_report/tests/test_invoice_report_basic.py
@@ -2,9 +2,10 @@
 # Basic sanity tests for l10n_ro_invoice_report
 # Goal: ensure the report action exists, templates are available, and report renders.
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestL10nRoInvoiceReportBasics(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/l10n_ro_invoice_report/tests/test_multi_company.py
+++ b/l10n_ro_invoice_report/tests/test_multi_company.py
@@ -77,7 +77,7 @@ class TestL10nRoInvoiceReportMultiCompany(TransactionCase):
                 "company_id": self.company_a.id,
                 "journal_id": self.env["account.journal"]
                 .with_company(self.company_a)
-                .search([("type", "=", "sale")], limit=1)
+                .search([("type", "=", "sale"), ("company_id", "=", self.company_a.id)], limit=1)
                 .id,
                 "invoice_line_ids": [
                     (

--- a/l10n_ro_invoice_report/views/invoice_report.xml
+++ b/l10n_ro_invoice_report/views/invoice_report.xml
@@ -50,7 +50,7 @@
 
             <div name="information_block" class="col-6">
                 <div>
-                    <strong t-if="o.move_type in ['out_invoice', 'out_refund']">Supplier:
+                    <strong t-if="o.move_type in ['out_invoice', 'out_refund', 'out_receipt']">Supplier:
                     </strong>
                     <strong t-if="o.move_type in ['in_invoice', 'in_refund']">Customer:
                     </strong>
@@ -117,7 +117,7 @@
             </div>
             <div class="col-5 offset-1">
                 <div>
-                    <strong t-if="o.move_type in ['out_invoice', 'out_refund']">Customer:
+                    <strong t-if="o.move_type in ['out_invoice', 'out_refund', 'out_receipt']">Customer:
                     </strong>
                     <strong t-if="o.move_type in ['in_invoice', 'in_refund']">Supplier:
                     </strong>
@@ -171,6 +171,9 @@
             <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
             <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
             <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
+            <span t-elif="o.move_type == 'out_receipt' and o.state == 'posted'">Sales Receipt</span>
+            <span t-elif="o.move_type == 'out_receipt' and o.state == 'draft'">Draft Sales Receipt</span>
+            <span t-elif="o.move_type == 'out_receipt' and o.state == 'cancel'">Cancelled Sales Receipt</span>
             <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
             <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
             <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
@@ -745,7 +748,7 @@
                 />
             </div>
             <t t-set="has_bf" t-value="o.is_bf_printed()" />
-            <t t-if="print_with_payments and not has_bf">
+            <t t-if="(print_with_payments or o.move_type == 'out_receipt') and not has_bf">
                 <t
                     t-set="payments_vals"
                     t-value="o.sudo().invoice_payments_widget and o.sudo().invoice_payments_widget['content'] or []"
@@ -830,7 +833,8 @@
                                 )
                             </div>
                             <div>
-                                Representing counter value of invoice
+                                <t t-if="o.move_type == 'out_receipt'">Representing counter value of sales receipt</t>
+                                <t t-else="">Representing counter value of invoice</t>
                                 <span t-field="o.name" />
                             </div>
 


### PR DESCRIPTION
## What

When printing an `out_receipt` (bon) document, the attached cash payment (chitanța) is now always printed, on any report variant — previously the payment block was only rendered by the *Invoices with Payments* report.

## Changes

- payment block condition extended: `(print_with_payments or o.move_type == 'out_receipt') and not has_bf`
- header: `Sales Receipt` / `Draft` / `Cancelled` title and Supplier/Customer labels for `out_receipt` (previously printed without title/labels)
- dedicated wording: *Representing counter value of sales receipt*
- `is_bf_printed()` now only applies to `out_invoice`
- refactor: `ResCompany` moved to its own `res_company.py`
- tests: fix multi-company journal search (was picking the wrong company's journal), tag basic tests `post_install`
- Romanian translations added for the new terms
- version bump `18.0.3.4.28`

## Verification

On a fresh DB:
- posted `out_receipt` + cash payment → chitanța rendered, including on the plain (without payments) report
- regular `out_invoice` → chitanța rendered only on the *with payments* report, unchanged behaviour
- bank/card payments still excluded (cash-only filter kept)
- module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)