### PR TITLE
[IMP] l10n_ro_invoice_report: etichetă Proforma + payment_reference pe ciornă

### DIFF
--- a/l10n_ro_invoice_report/__manifest__.py
+++ b/l10n_ro_invoice_report/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Romania - Invoice Report Terrabit",
     "summary": "Localizare Terrabit - Facturi, Chitanta",
-    "version": "19.0.3.4.16",
+    "version": "19.0.3.4.17",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "license": "AGPL-3",

--- a/l10n_ro_invoice_report/views/invoice_report.xml
+++ b/l10n_ro_invoice_report/views/invoice_report.xml
@@ -166,14 +166,15 @@
         <br/>
         <h2>
             <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
-            <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
+            <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Proforma</span>
             <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>
             <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
             <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
             <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
             <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
             <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
-            <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
+            <span t-if="o.name != '/'" t-field="o.name"/>
+            <span t-if="not o.name and o.move_type == 'out_invoice' and o.state == 'draft' and o.payment_reference" t-field="o.payment_reference"/>
         </h2>
 
     </template>


### PR DESCRIPTION
## Modificări

`l10n_ro_invoice_report/views/invoice_report.xml`:
- Facturile client în stare **draft** afișează acum **Proforma** în titlu (în loc de „Draft Invoice"), pentru a reflecta utilizarea ca proformă.
- Pentru proformele fără număr alocat încă (`o.name == '/'`), se afișează `payment_reference` în titlu, ca identificator de referință.

`__manifest__.py`: bump versiune `19.0.3.4.16` → `19.0.3.4.17`.

> Notă: în timpul pregătirii PR-ului am corectat o greșeală de tipar din modificarea inițială (`Profomra` → `Proforma`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)