### PR TITLE
[FIX] l10n_ro_efactura_enhancement: handle non-RO partners for SPV

### DIFF
--- a/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
@@ -386,7 +386,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         res = super()._ubl_add_accounting_customer_party_tax_scheme_nodes(vals)
         if vals["party_node"]["cac:PartyTaxScheme"]:
             if (
-                "RO" not in vals["party_node"]["cac:PartyTaxScheme"][0]["cbc:CompanyID"]["_text"]
+                commercial_partner.country_id.code == "RO"
+                and "RO" not in vals["party_node"]["cac:PartyTaxScheme"][0]["cbc:CompanyID"]["_text"]
                 and commercial_partner.is_company
                 and commercial_partner.vat
             ):

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -134,6 +134,18 @@ class AccountMove(models.Model):
         if not invoices:
             raise UserError(_("Nu exista facturi confirmate selectate pentru trimitere in SPV."))
 
+        # SPV / e-Factura se aplica doar partenerilor din Romania. Excludem facturile
+        # catre clienti non-RO ca sa nu fie trimise accidental in SPV.
+        non_ro_invoices = invoices.filtered(lambda m: m.commercial_partner_id.country_id.code != "RO")
+        if non_ro_invoices:
+            _logger.info(
+                "⏭️ Skipping non-RO invoices for SPV: %s",
+                non_ro_invoices.mapped("name"),
+            )
+        invoices = invoices - non_ro_invoices
+        if not invoices:
+            raise UserError(_("Facturile selectate au clienti din afara Romaniei si nu pot fi trimise in SPV."))
+
         self.env["account.move.send"]._generate_and_send_invoices(
             invoices,
             sending_methods={"manual"},

--- a/l10n_ro_efactura_enhancement/tests/test_spv_actions.py
+++ b/l10n_ro_efactura_enhancement/tests/test_spv_actions.py
@@ -24,17 +24,28 @@ class TestSpvActions(TransactionCase):
                 "invoice_sending_method": "email",
             }
         )
+        # Client companie din afara Romaniei (intracomunitar) cu VAT EU
+        cls.foreign_partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner Foreign",
+                "is_company": True,
+                "country_id": cls.env.ref("base.ie").id,
+                "city": "Dublin",
+                "street": "Main Street 1",
+                "vat": "IE6388047V",
+            }
+        )
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Test Product SPV",
             }
         )
 
-    def _create_posted_invoice(self):
+    def _create_posted_invoice(self, partner=None):
         invoice = self.env["account.move"].create(
             {
                 "move_type": "out_invoice",
-                "partner_id": self.partner.id,
+                "partner_id": (partner or self.partner).id,
                 "invoice_line_ids": [
                     (
                         0,
@@ -88,6 +99,35 @@ class TestSpvActions(TransactionCase):
             self.assertEqual(kwargs.get("sending_methods"), {"manual"})
         # Partenerul nu trebuie modificat
         self.assertEqual(self.partner.invoice_sending_method, "email")
+
+    def test_action_send_to_spv_only_excludes_non_ro(self):
+        """Test că facturile catre clienti non-RO sunt excluse de la trimiterea in SPV."""
+        ro_invoice = self._create_posted_invoice()
+        foreign_invoice = self._create_posted_invoice(partner=self.foreign_partner)
+        invoices = ro_invoice | foreign_invoice
+        with patch.object(
+            type(self.env["account.move.send"]),
+            "_generate_and_send_invoices",
+        ) as mock_send:
+            invoices.action_send_to_spv_only()
+            args, kwargs = mock_send.call_args
+            sent_invoices = args[0]
+            # Doar factura RO trebuie trimisa, cea straina exclusa
+            self.assertIn(ro_invoice, sent_invoices)
+            self.assertNotIn(foreign_invoice, sent_invoices)
+
+    def test_action_send_to_spv_only_all_non_ro_raises(self):
+        """Test că acțiunea ridică UserError dacă toate facturile selectate sunt non-RO."""
+        foreign_invoice = self._create_posted_invoice(partner=self.foreign_partner)
+        with self.assertRaises(UserError):
+            foreign_invoice.action_send_to_spv_only()
+
+    def test_foreign_company_vat_not_prefixed_with_ro(self):
+        """Test că VAT-ul unei companii straine nu este prefixat cu 'RO' in XML-ul e-Factura."""
+        invoice = self._create_posted_invoice(partner=self.foreign_partner)
+        xml_content, _errors = self.env["account.edi.xml.ubl_ro"]._export_invoice(invoice)
+        self.assertIn(b"IE6388047V", xml_content)
+        self.assertNotIn(b"ROIE6388047V", xml_content)
 
     def test_spv_cron_no_email_config(self):
         """Test că setarea l10n_ro_spv_cron_no_email se salvează corect pe companie."""


### PR DESCRIPTION
## Context

Pentru clienții din afara României, modulul trata greșit trimiterea în SPV / e-Factura:

1. **VAT prefixat greșit cu "RO"** — în `_ubl_add_accounting_customer_party_tax_scheme_nodes`, orice companie cu VAT al cărei `CompanyID` nu conținea "RO" primea prefixul `RO`, transformând ex. `IE6388047V` în `ROIE6388047V` (VAT invalid).
2. **Server action „Trimite în SPV" fără filtru de țară** — `action_send_to_spv_only` putea trimite accidental facturi de export/intracomunitar în SPV.

## Modificări

- Prefixarea cu `RO` se aplică acum doar partenerilor cu `country_id.code == "RO"`.
- `action_send_to_spv_only` exclude facturile cu client non-RO și ridică `UserError` dacă toate selectate sunt non-RO.
- Teste noi în `tests/test_spv_actions.py`:
  - `test_action_send_to_spv_only_excludes_non_ro`
  - `test_action_send_to_spv_only_all_non_ro_raises`
  - `test_foreign_company_vat_not_prefixed_with_ro`

## Testare

`8 passed, 0 failed, 0 error` pentru `TestSpvActions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)