### PR TITLE
[FIX] l10n_ro_efactura_enhancement: fix SPV auto-send cron crash

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.2.9",
+    "version": "18.0.0.2.10",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -140,11 +140,23 @@ class AccountMove(models.Model):
 
                 sending_methods = {"manual"} if company.l10n_ro_spv_cron_no_email else None
                 kwargs = {"sending_methods": sending_methods} if sending_methods else {}
-                # from_cron=True: errors are logged on each move's chatter instead
-                # of raising, so one broken invoice no longer aborts the batch.
+
+                # Attribute the send to OdooBot instead of whoever happens to run
+                # the cron, so the chatter/tracking shows a stable system author.
+                odoobot = self.env.ref("base.user_root")
+                kwargs["author_user_id"] = odoobot.id
+                kwargs["author_partner_id"] = odoobot.partner_id.id
+
+                # allow_raising=False: errors are logged on each move's chatter
+                # instead of raising, so one broken invoice no longer aborts the
+                # batch. We must NOT use from_cron=True here: that branch reads
+                # move.sending_data (a Json field), which is only populated by the
+                # Send & Print wizard. Since this cron sends invoices directly,
+                # sending_data stays False and from_cron=True would crash with
+                # "'bool' object has no attribute 'get'".
                 self.env["account.move.send"]._generate_and_send_invoices(
                     invoices,
-                    from_cron=True,
+                    allow_raising=False,
                     **kwargs,
                 )
 

--- a/l10n_ro_efactura_enhancement/views/res_config_settings_views.xml
+++ b/l10n_ro_efactura_enhancement/views/res_config_settings_views.xml
@@ -6,11 +6,12 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//block[@id='invoicing_settings']" position="after">
-                <div id="l10n_ro_efactura">
-                    <h2>eFactura SPV</h2>
+                <block title="eFactura SPV" id="l10n_ro_efactura">
                     <setting
                         title="Când este activat, cron-ul de trimitere automată în SPV nu va trimite facturile și pe email."
                         id="l10n_ro_spv_cron_no_email"
+                        string="Trimite în SPV fără email (cron)"
+                        help="Cron-ul de trimitere automată în SPV nu va trimite facturile și pe email."
                     >
                         <field name="l10n_ro_spv_cron_no_email" />
                     </setting>
@@ -18,13 +19,14 @@
                         title="Adrese de email care primesc statistica după fiecare rulare a cronului de trimitere în SPV. Dacă e gol, se folosește emailul companiei."
                         id="l10n_ro_spv_cron_report_email"
                         string="Email raport cron SPV"
+                        help="Adrese de email (separate prin virgulă) care primesc statistica după fiecare rulare a cronului. Dacă e gol, se folosește emailul companiei."
                     >
                         <field
                             name="l10n_ro_spv_cron_report_email"
                             placeholder="contabilitate@firma.ro, manager@firma.ro"
                         />
                     </setting>
-                </div>
+                </block>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Problema

Cron-ul de trimitere automată în SPV (`_cron_l10n_ro_edi_auto_send`) apela `_generate_and_send_invoices` cu `from_cron=True`. Acel branch citește `move.sending_data` (`fields.Json`), populat **doar** de wizard-ul *Send & Print*. Cum cron-ul trimite facturile direct, `sending_data` rămânea `False` și se arunca:

```
AttributeError: 'bool' object has no attribute 'get'
```

## Soluția

- `allow_raising=False` în loc de `from_cron=True` — păstrează comportamentul „loghează pe chatter, nu opri batch-ul” fără a atinge `sending_data`.
- Atribuie trimiterea către **OdooBot** (`base.user_root`) ca autor stabil, indiferent de userul care rulează cron-ul.
- **Settings layout:** `<block>` în loc de `<div>`/`<h2>` ca secțiunea să se alinieze în grila standard de Settings; adăugat `string`/`help`.
- Versiune: `18.0.0.2.9` → `18.0.0.2.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)