### PR TITLE
[IMP] l10n_ro_efactura_enhancement: split SPV report by validation state

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.2.10",
+    "version": "18.0.0.2.11",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -161,15 +161,22 @@ class AccountMove(models.Model):
                 )
 
             # Recompute states after the send to build the run report.
+            # NB: 'invoice_sent' only means the XML was uploaded to the SPV and is
+            # awaiting validation — the SPV can still reject it later (async, via
+            # the fetch-status cron). Only 'invoice_validated' is a confirmed
+            # success, so we report the two separately instead of lumping them as
+            # "sent successfully".
             invoices.invalidate_recordset(["l10n_ro_edi_state"])
-            sent_ok = invoices.filtered(lambda inv: inv.l10n_ro_edi_state in ("invoice_sent", "invoice_validated"))
-            failed_now = invoices - sent_ok
+            validated = invoices.filtered(lambda inv: inv.l10n_ro_edi_state == "invoice_validated")
+            pending = invoices.filtered(lambda inv: inv.l10n_ro_edi_state == "invoice_sent")
+            failed_now = invoices - validated - pending
             self._l10n_ro_spv_send_cron_report(
                 company,
                 {
                     "candidates": candidates,
                     "attempted": invoices,
-                    "sent_ok": sent_ok,
+                    "validated": validated,
+                    "pending": pending,
                     "failed_now": failed_now,
                     "retrying": retrying,
                     "exhausted": exhausted,
@@ -215,7 +222,12 @@ class AccountMove(models.Model):
             return shown
 
         rows = [
-            (_("Trimise cu succes în SPV"), len(stats["sent_ok"]), _names(stats["sent_ok"])),
+            (_("Validate de SPV"), len(stats["validated"]), _names(stats["validated"])),
+            (
+                _("Trimise în SPV — în așteptare validare"),
+                len(stats["pending"]),
+                _names(stats["pending"]),
+            ),
             (_("Eșuate la această rulare"), len(stats["failed_now"]), _names(stats["failed_now"])),
             (_("Reîncercări (eșuaseră anterior)"), len(stats["retrying"]), _names(stats["retrying"])),
             (


### PR DESCRIPTION
## Context

În raportul cron de trimitere SPV, categoria „Trimise cu succes în SPV" amesteca două stări diferite:
- `invoice_sent` = XML încărcat în SPV, **în așteptarea validării**
- `invoice_validated` = **validat** de SPV

Problema: SPV poate respinge factura **ulterior** (asincron, prin cron-ul de fetch-status), deci o factură raportată ca „succes" la rulare putea apărea apoi cu starea „Eroare". Asta făcea raportul să pară inconsistent cu starea reală a facturii.

## Soluția

Am separat bucket-ul de succes în două rânduri:
- **Validate de SPV** (`invoice_validated`) — succes confirmat
- **Trimise în SPV — în așteptare validare** (`invoice_sent`) — încărcate, urmează validarea

Versiune: `18.0.0.2.10` → `18.0.0.2.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)