### PR TITLE
[IMP] l10n_ro_efactura_enhancement: send SPV cron report via mail.template

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.2.12",
+    "version": "18.0.0.2.13",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",
@@ -24,6 +24,7 @@
         # "wizard/account_move_send_views.xml",
         "data/ir_cron.xml",
         "data/server_action.xml",
+        "data/mail_template_spv_cron_report.xml",
         "views/account_move.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/l10n_ro_efactura_enhancement/data/mail_template_spv_cron_report.xml
+++ b/l10n_ro_efactura_enhancement/data/mail_template_spv_cron_report.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mail_template_l10n_ro_spv_cron_report" model="mail.template">
+        <field name="name">e-Factura SPV: Raport rulare cron</field>
+        <field name="model_id" ref="base.model_res_company" />
+        <field name="email_from">{{ object.email or (object.partner_id and object.partner_id.email) or '' }}</field>
+        <field name="subject">[{{ object.name }}] Raport e-Factura SPV</field>
+        <field name="email_layout_xmlid">mail.mail_notification_light</field>
+        <field name="body_html" type="html">
+            <div>
+                <p>
+                    Raport rulare cron trimitere e-Factura în SPV —
+                    <strong t-out="object.name">Companie</strong>
+                    <br />
+                    Data rulării:
+                    <t t-out="ctx.get('spv_run')">—</t>
+                </p>
+                <p>
+                    Total facturi procesate la această rulare:
+                    <strong t-out="ctx.get('spv_total')">0</strong>
+                </p>
+                <table style="border-collapse:collapse;font-size:13px;">
+                    <tr style="background:#f5f5f5;">
+                        <th style="padding:4px 8px;border:1px solid #ddd;text-align:left;">Categorie</th>
+                        <th style="padding:4px 8px;border:1px solid #ddd;">Nr.</th>
+                        <th style="padding:4px 8px;border:1px solid #ddd;text-align:left;">Facturi</th>
+                    </tr>
+                    <t t-foreach="ctx.get('spv_rows', [])" t-as="row">
+                        <tr>
+                            <td style="padding:4px 8px;border:1px solid #ddd;" t-out="row[0]" />
+                            <td style="padding:4px 8px;border:1px solid #ddd;text-align:right;"><strong
+                                    t-out="row[1]"
+                                >0</strong></td>
+                            <td style="padding:4px 8px;border:1px solid #ddd;color:#666;" t-out="row[2]" />
+                        </tr>
+                    </t>
+                </table>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -300,37 +300,33 @@ class AccountMove(models.Model):
                 _names(exhausted),
             ),
         ]
-        body_rows = "".join(
-            "<tr>"
-            f"<td style='padding:4px 8px;border:1px solid #ddd;'>{label}</td>"
-            f"<td style='padding:4px 8px;border:1px solid #ddd;text-align:right;'><b>{count}</b></td>"
-            f"<td style='padding:4px 8px;border:1px solid #ddd;color:#666;'>{names}</td>"
-            "</tr>"
-            for label, count, names in rows
-        )
+        # Send through the standard mail.template mechanism (QWeb body + Odoo
+        # email layout) instead of a raw mail.mail. The per-run stats are passed
+        # to the template via the rendering context (exposed as ``ctx`` inside
+        # the QWeb body_html). NB: this report goes to the internal accounting
+        # team and is sent regardless of the company's "send without email"
+        # setting, which only suppresses the customer invoice email.
         now = fields.Datetime.now()
-        body = (
-            f"<p>{_('Raport rulare cron trimitere e-Factura în SPV')} — "
-            f"<b>{company.name}</b><br/>"
-            f"{_('Data rulării')}: {fields.Datetime.to_string(now)}</p>"
-            f"<p>{_('Total facturi procesate la această rulare')}: "
-            f"<b>{len(stats['attempted'])}</b></p>"
-            "<table style='border-collapse:collapse;font-size:13px;'>"
-            f"<tr style='background:#f5f5f5;'>"
-            f"<th style='padding:4px 8px;border:1px solid #ddd;text-align:left;'>{_('Categorie')}</th>"
-            f"<th style='padding:4px 8px;border:1px solid #ddd;'>{_('Nr.')}</th>"
-            f"<th style='padding:4px 8px;border:1px solid #ddd;text-align:left;'>{_('Facturi')}</th>"
-            f"</tr>{body_rows}</table>"
+        template = self.env.ref(
+            "l10n_ro_efactura_enhancement.mail_template_l10n_ro_spv_cron_report",
+            raise_if_not_found=False,
         )
-
-        mail_values = {
-            "subject": _("[%s] Raport e-Factura SPV") % company.name,
-            "body_html": body,
-            "email_to": recipients,
-            "email_from": company.email or company.partner_id.email or recipients,
-            "auto_delete": True,
-        }
-        self.env["mail.mail"].sudo().create(mail_values).send()
+        if not template:
+            _logger.warning("⚠️ SPV cron report template not found; skipping report for %s", company.name)
+            return
+        template.with_context(
+            spv_rows=rows,
+            spv_total=len(stats["attempted"]),
+            spv_run=fields.Datetime.to_string(now),
+        ).sudo().send_mail(
+            company.id,
+            force_send=True,
+            email_values={
+                "email_to": recipients,
+                "email_from": company.email or company.partner_id.email or recipients,
+                "auto_delete": True,
+            },
+        )
         _logger.info("📧 SPV cron report sent to %s for %s", recipients, company.name)
 
     def action_send_to_spv_only(self):


### PR DESCRIPTION
## Context

Emailul statistic (raportul de rulare a cron-ului SPV) era construit ca HTML brut și trimis printr-un `mail.mail` direct. Acum folosește **mecanismul standard**: un `mail.template` cu body QWeb + layout-ul standard Odoo (`mail.mail_notification_light`), deci raportul are branding consistent și e ușor de personalizat.

## Detalii

- Statisticile per rulare se pasează template-ului prin **contextul de randare** (expus ca `ctx` în `body_html`).
- Raportul merge tot către echipa internă de contabilitate și se trimite **indiferent** de bifa „Trimite în SPV fără email (cron)" — acea bifă suprimă doar emailul cu factura către client (conform deciziei).

## Verificat pe `o18_test`

- Update modul + post-migration: rulare curată, fără erori.
- Template-ul randează corect (categorii, dată rulare, listă facturi) și `send_mail` generează `mail.mail`-ul cu subiect, layout și tabel — fără erori.

Versiune: `18.0.0.2.12` → `18.0.0.2.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)