### PR TITLE
[FIX] l10n_ro_efactura_enhancement: handle None Description/Name nodes (SPV crash)

### DIFF
--- a/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
@@ -56,8 +56,15 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         # Ensure structure exists and apply safe truncation for product-based defaults
         product = vals["base_line"]["product_id"]
         item = line_node.setdefault("cac:Item", {})
-        desc = item.setdefault("cbc:Description", {})
-        name = item.setdefault("cbc:Name", {})
+        # Odoo 19 core (commit aeb41ca7) poate seta aceste noduri pe None
+        # (ca tag-ul gol să fie sărit la serializare); setdefault ar întoarce
+        # atunci None și am crăpa la atribuirea "_text". Normalizăm la dict.
+        if not isinstance(item.get("cbc:Description"), dict):
+            item["cbc:Description"] = {}
+        if not isinstance(item.get("cbc:Name"), dict):
+            item["cbc:Name"] = {}
+        desc = item["cbc:Description"]
+        name = item["cbc:Name"]
         # Default from product, truncated
         if not desc.get("_text"):
             default_desc = product.description_sale or product.name or ""
@@ -97,8 +104,14 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         use_line_desc = safe_eval(get_param("efactura.use_line_description", "False"))
         replace_unit_uom = safe_eval(get_param("efactura.replace_unit_uom", "False"))
         item = line_node.setdefault("cac:Item", {})
-        desc = item.setdefault("cbc:Description", {})
-        name = item.setdefault("cbc:Name", {})
+        # Vezi nota din _add_document_line_item_nodes: core-ul poate seta nodurile
+        # pe None, deci nu ne putem baza pe setdefault.
+        if not isinstance(item.get("cbc:Description"), dict):
+            item["cbc:Description"] = {}
+        if not isinstance(item.get("cbc:Name"), dict):
+            item["cbc:Name"] = {}
+        desc = item["cbc:Description"]
+        name = item["cbc:Name"]
         if use_line_desc:
             line = vals["base_line"]["record"]
             # Normalize and truncate the line description
@@ -111,10 +124,16 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         # When a free-text line description is used, drop additional properties
         if item.get("cac:AdditionalItemProperty"):
             item["cac:AdditionalItemProperty"] = []
-        if desc:
-            line_node["cac:Item"]["cbc:Description"]["_text"] = desc["_text"][:200]
-        if name:
-            line_node["cac:Item"]["cbc:Name"]["_text"] = name["_text"][:100]
+        # Truncare la limitele ANAF; dacă un nod a rămas gol îl punem înapoi pe
+        # None ca serializatorul să sară peste tag-ul (opțional) gol.
+        if desc.get("_text"):
+            desc["_text"] = desc["_text"][:200]
+        else:
+            item["cbc:Description"] = None
+        if name.get("_text"):
+            name["_text"] = name["_text"][:100]
+        else:
+            item["cbc:Name"] = None
         # replace line uom if parameter is set for unit
         if (
             replace_unit_uom


### PR DESCRIPTION
## Problemă

Trimiterea facturilor în SPV crăpa cu:

```
TypeError: 'NoneType' object does not support item assignment
  File ".../l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py", line 107, in _add_invoice_line_item_nodes
    desc["_text"] = description[:200]
```

## Cauză

Core-ul Odoo (commit `aeb41ca7`, *[IMP] account_edi_ubl_cii: refactor the import/export of line name and line description*) setează acum **explicit** `cac:Item/cbc:Description` și `cbc:Name` pe `None` când linia nu are descriere/nume (ca tag-ul gol să fie sărit la serializare).

Modulul se baza pe `item.setdefault("cbc:Description", {})`, care întoarce `None` când cheia *există deja* cu valoarea `None` → crash la `desc["_text"] = ...`. Se declanșa pe liniile unde descrierea iese goală (ex. `line.name == product.display_name`).

## Fix

În `_add_document_line_item_nodes` și `_add_invoice_line_item_nodes`:
- normalizăm nodurile la `dict` înainte de a scrie `_text` (defensiv față de `None`);
- la final, dacă un nod a rămas gol, îl punem înapoi pe `None` ca serializatorul să sară peste tag-ul opțional gol.

## Test

Reprodus și verificat pe baza `terrabit19` (în tranzacție cu rollback):

| Versiune | Rezultat |
|---|---|
| înainte de fix | `TypeError 'NoneType' object does not support item assignment` |
| după fix | export OK, XML valid cu `<cbc:Description>` + `<cbc:Name>` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)