### PR TITLE
[FIX] l10n_ro_efactura_enhancement: embed_pdf O19 + parametri config

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "19.0.0.3.10",
+    "version": "19.0.0.3.11",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/data/ir_config_parameter.xml
+++ b/l10n_ro_efactura_enhancement/data/ir_config_parameter.xml
@@ -8,6 +8,14 @@
             <field name="key">efactura.use_line_description</field>
             <field name="value">False</field>
         </record>
+        <record model="ir.config_parameter" id="efactura_get_all_banks">
+            <field name="key">efactura.get_all_banks</field>
+            <field name="value">False</field>
+        </record>
+        <record model="ir.config_parameter" id="efactura_replace_unit_uom">
+            <field name="key">efactura.replace_unit_uom</field>
+            <field name="value">False</field>
+        </record>
 <!--     <record model="ir.config_parameter" id="efactura_clean_name">-->
 <!--            <field name="key">efactura.clean_name</field>-->
 <!--            <field name="value">False</field>-->

--- a/l10n_ro_efactura_enhancement/wizard/__init__.py
+++ b/l10n_ro_efactura_enhancement/wizard/__init__.py
@@ -1,2 +1,3 @@
-# from . import account_move_send
+from . import account_move_send
+
 # from . import efactura_dashboard

--- a/l10n_ro_efactura_enhancement/wizard/account_move_send.py
+++ b/l10n_ro_efactura_enhancement/wizard/account_move_send.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import api, models
+from odoo import models
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -21,6 +21,19 @@ class AccountMoveSend(models.AbstractModel):
                 context.pop("lastcall", None)
 
         return alerts
+
+    def _postprocess_invoice_ubl_xml(self, invoice, invoice_data):
+        # EXTENDS account_edi_ubl_cii
+        # În O19 metoda trăiește pe modelul abstract account.move.send (nu pe
+        # wizard, ca în 18.0), iar fluxul de trimitere o apelează de pe acesta.
+        # Override-ul de pe account.move.send.wizard nu se mai declanșa, deci
+        # parametrul efactura.embed_pdf era ignorat. Îl mutăm aici ca să rămână
+        # funcțional: dacă embed_pdf e False, nu atașăm PDF-ul în XML-ul UBL.
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        embed_pdf = safe_eval(get_param("efactura.embed_pdf", "False"))
+        if not embed_pdf:
+            return
+        return super()._postprocess_invoice_ubl_xml(invoice, invoice_data)
 
 
 class AccountMoveSendWizard(models.TransientModel):
@@ -53,13 +66,3 @@ class AccountMoveSendWizard(models.TransientModel):
         }
 
     # _compute_l10n_ro_edi_send_enable nu mai exista in v19 standard
-
-    @api.model
-    def _postprocess_invoice_ubl_xml(self, invoice, invoice_data):
-        # Adding the PDF to the XML
-
-        get_param = self.env["ir.config_parameter"].sudo().get_param
-        embed_pdf = safe_eval(get_param("efactura.embed_pdf", "False"))
-        if not embed_pdf:
-            return
-        return super()._postprocess_invoice_ubl_xml(invoice, invoice_data)


### PR DESCRIPTION
## Context
Aliniere 18.0 → 19.0 pentru `l10n_ro_efactura_enhancement`. Două goluri reale găsite la verificarea de drift.

## Gol 1 — `efactura.embed_pdf` ignorat în O19
În O19, `_postprocess_invoice_ubl_xml` a fost mutată de pe `account.move.send.wizard` pe modelul abstract `account.move.send`, iar fluxul de trimitere o apelează de pe acesta. Override-ul modulului rămăsese pe wizard → **nu se mai declanșa**, deci PDF-ul era mereu inclus în XML-ul UBL indiferent de parametru. De-aceea fusese dezactivat tot fișierul wizard.

**Fix:** mut override-ul pe `account.move.send` și reactivez importul wizard-ului. Acum, cu `efactura.embed_pdf = False`, PDF-ul nu mai e atașat — comportament echivalent cu 18.0.

## Gol 3 — parametri de config fără valoare implicită
`efactura.get_all_banks` și `efactura.replace_unit_uom` erau citiți din cod fără înregistrare în `ir_config_parameter.xml`. Adaug ambele (valoare `False`) ca să fie vizibile/editabile fără creare manuală.

## Verificare
- `-u l10n_ro_efactura_enhancement` pe `test19` → exit 0, fără erori.
- Parametrii apar în DB cu valorile corecte (`get_all_banks=False`, `replace_unit_uom=False`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)