### PR TITLE
[FIX] l10n_ro_efactura_enhancement: valori implicite parametri config (18.0)

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.2.13",
+    "version": "18.0.0.2.14",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/data/ir_config_parameter.xml
+++ b/l10n_ro_efactura_enhancement/data/ir_config_parameter.xml
@@ -8,6 +8,14 @@
             <field name="key">efactura.use_line_description</field>
             <field name="value">False</field>
         </record>
+        <record model="ir.config_parameter" id="efactura_get_all_banks">
+            <field name="key">efactura.get_all_banks</field>
+            <field name="value">False</field>
+        </record>
+        <record model="ir.config_parameter" id="efactura_replace_unit_uom">
+            <field name="key">efactura.replace_unit_uom</field>
+            <field name="value">False</field>
+        </record>
 <!--     <record model="ir.config_parameter" id="efactura_clean_name">-->
 <!--            <field name="key">efactura.clean_name</field>-->
 <!--            <field name="value">False</field>-->


### PR DESCRIPTION
## Context
La verificarea de aliniere 18.0 ↔ 19.0 a ieșit că parametrii `efactura.get_all_banks` și `efactura.replace_unit_uom` (citiți în `account_edi_xml_cius_ro.py`) nu aveau înregistrare implicită în `data/ir_config_parameter.xml`.

## Fix
Adaug ambele înregistrări (valoare `False`) ca să fie vizibile și editabile fără creare manuală. Bump versiune `18.0.0.2.14`.

> Echivalentul pe 19.0 e în PR #428 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)