### PR TITLE
[IMP] l10n_ro_efactura_enhancement: nu se mai trimite raportul cron SPV pe emailul companiei

### DIFF
--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -256,10 +256,11 @@ class AccountMove(models.Model):
     def _l10n_ro_spv_send_cron_report(self, company, stats):
         """Send a statistics email summarizing one SPV auto-send cron run.
 
-        Recipients come from ``company.l10n_ro_spv_cron_report_email`` (comma
-        separated), falling back to the company email. Nothing is sent on a
-        fully idle run (no candidates and no retry-exhausted invoices) to avoid
-        empty nightly emails.
+        Recipients come exclusively from ``company.l10n_ro_spv_cron_report_email``
+        (comma separated). When that field is empty the report is not sent (no
+        fallback to the company email). Nothing is sent on a fully idle run (no
+        candidates and no retry-exhausted invoices) to avoid empty nightly
+        emails.
         """
         candidates = stats["candidates"]
         exhausted = stats["exhausted"]
@@ -267,11 +268,10 @@ class AccountMove(models.Model):
             _logger.info("ℹ️ SPV cron report skipped for %s: nothing to report", company.name)
             return
 
-        recipients = company.l10n_ro_spv_cron_report_email or company.email or company.partner_id.email
+        recipients = company.l10n_ro_spv_cron_report_email
         if not recipients:
-            _logger.warning(
-                "⚠️ SPV cron report not sent for %s: no recipient configured "
-                "(set 'Email raport cron SPV' or the company email)",
+            _logger.info(
+                "ℹ️ SPV cron report not sent for %s: 'Email raport cron SPV' not set",
                 company.name,
             )
             return

--- a/l10n_ro_efactura_enhancement/models/res_config_settings.py
+++ b/l10n_ro_efactura_enhancement/models/res_config_settings.py
@@ -14,8 +14,8 @@ class ResCompany(models.Model):
     l10n_ro_spv_cron_report_email = fields.Char(
         string="Email raport cron SPV",
         help="Adrese de email (separate prin virgula) care primesc statistica dupa "
-        "fiecare rulare a cronului de trimitere in SPV. Daca e gol, se foloseste "
-        "emailul companiei.",
+        "fiecare rulare a cronului de trimitere in SPV. Daca e gol, raportul nu se "
+        "trimite.",
     )
 
 

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,10 @@
+## 18.0.0.2.14 (2026-06-18)
+
+- **SPV cron report no longer falls back to the company email.** Recipients
+  come exclusively from `l10n_ro_spv_cron_report_email`; when that field is
+  empty the report is simply not sent (previously it fell back to the company
+  email). Help texts and the settings view were updated accordingly.
+
 ## 18.0.0.2.13 (2026-06-09)
 
 - **SPV cron report email** now uses the standard `mail.template` mechanism

--- a/l10n_ro_efactura_enhancement/views/res_config_settings_views.xml
+++ b/l10n_ro_efactura_enhancement/views/res_config_settings_views.xml
@@ -16,10 +16,10 @@
                         <field name="l10n_ro_spv_cron_no_email" />
                     </setting>
                     <setting
-                        title="Adrese de email care primesc statistica după fiecare rulare a cronului de trimitere în SPV. Dacă e gol, se folosește emailul companiei."
+                        title="Adrese de email care primesc statistica după fiecare rulare a cronului de trimitere în SPV. Dacă e gol, raportul nu se trimite."
                         id="l10n_ro_spv_cron_report_email"
                         string="Email raport cron SPV"
-                        help="Adrese de email (separate prin virgulă) care primesc statistica după fiecare rulare a cronului. Dacă e gol, se folosește emailul companiei."
+                        help="Adrese de email (separate prin virgulă) care primesc statistica după fiecare rulare a cronului. Dacă e gol, raportul nu se trimite."
                     >
                         <field
                             name="l10n_ro_spv_cron_report_email"


### PR DESCRIPTION
## Context

Raportul de statistică al cronului de trimitere în SPV folosea ca destinatari `l10n_ro_spv_cron_report_email`, iar dacă acel câmp era gol făcea **fallback la emailul companiei** (`company.email` / `company.partner_id.email`). Comportamentul nedorit: raportul ajungea automat pe emailul companiei chiar dacă nu se configurase explicit un destinatar.

## Modificare

În `_l10n_ro_spv_send_cron_report`, destinatarii vin acum **exclusiv** din `l10n_ro_spv_cron_report_email`:

```python
# înainte
recipients = company.l10n_ro_spv_cron_report_email or company.email or company.partner_id.email
# acum
recipients = company.l10n_ro_spv_cron_report_email
```

Dacă acel câmp e gol → raportul **nu se mai trimite** (log `info`, nu eroare).

Note:
- `email_from` (expeditorul) rămâne neschimbat, cu fallback la emailul companiei.
- Help text-urile (Python + view-ul de settings) au fost actualizate pentru a reflecta noul comportament.
- HISTORY.md actualizat pentru versiunea `18.0.0.2.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)