### PR TITLE
[FIX] l10n_ro_stock_picking_report: sudo valuation layers in reception report

### DIFF
--- a/l10n_ro_stock_picking_report/__manifest__.py
+++ b/l10n_ro_stock_picking_report/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Romania - Terrabit - Picking Reports",
     "summary": "Rapoarte: NIR, aviz, bon consum",
     "license": "AGPL-3",
-    "version": "18.0.1.2.8",
+    "version": "18.0.1.2.9",
     "development_status": "Mature",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",

--- a/l10n_ro_stock_picking_report/readme/HISTORY.md
+++ b/l10n_ro_stock_picking_report/readme/HISTORY.md
@@ -1,0 +1,5 @@
+## 18.0.1.2.9
+
+- Fix: reading stock valuation layers in the reception report (`_get_line`)
+  now uses `sudo()`. Standard Inventory users can print reception reports
+  without requiring direct read access to `stock.valuation.layer`.

--- a/l10n_ro_stock_picking_report/report/picking.py
+++ b/l10n_ro_stock_picking_report/report/picking.py
@@ -105,7 +105,10 @@ class ReportPickingReception(models.AbstractModel):
         value = 0
         quantity = 0
         unit_cost = 0.0
-        for valuation in move.stock_valuation_layer_ids:
+        # Read valuation layers with sudo so that standard Inventory users can
+        # print the report without needing direct access to stock.valuation.layer.
+        valuation_layers = move.sudo().stock_valuation_layer_ids
+        for valuation in valuation_layers:
             if valuation.l10n_ro_valued_type == "internal_transfer" and not valuation.account_move_id:
                 continue
             if valuation.l10n_ro_valued_type == "dropshipped" and valuation.value < 0:
@@ -114,7 +117,7 @@ class ReportPickingReception(models.AbstractModel):
             quantity += valuation.quantity
             if not unit_cost and valuation.unit_cost:
                 unit_cost = valuation.unit_cost
-        if move.stock_valuation_layer_ids:
+        if valuation_layers:
             res["price"] = (value / quantity if quantity else 0.0) or unit_cost
 
         currency = move.company_id.currency_id


### PR DESCRIPTION
## Problemă

Utilizatorul cu rol standard de **Inventar** primește eroare de acces la printarea unei recepții:

> Nu aveți permisiunea de a accesa înregistrările 'Nivel evaluare stoc' (stock.valuation.layer). Această operațiune este permisă pentru grupurile: Administrare/Setări, Inventar/Administrator.

(raportat pe dovacom, document sursă S20961)

## Cauză

Raportul de recepție rulează cu permisiunile utilizatorului care printează. Metoda `_get_line()` parcurgea `move.stock_valuation_layer_ids` pentru a calcula prețul/valoarea, ceea ce impunea acces de citire pe `stock.valuation.layer` — restricționat la grupurile *Administrare/Setări* și *Inventar/Administrator*.

## Soluție

Citirea straturilor de evaluare se face acum cu `sudo()`. Valoarea este calculată server-side și afișată intenționat în raport, deci utilizatorii standard de Inventar pot printa recepția fără acces direct la `stock.valuation.layer`.

Beneficiază de fix și raportul de transfer intern, care folosește același `_get_line`.

## Observație (în afara scopului acestui PR)

Bonul de consum (`report_consume_voucher`) accesează `move.stock_valuation_layer_ids` direct în QWeb, nu prin model — acolo `sudo()` nu se poate aplica ușor. Dacă apare aceeași eroare și la bonurile de consum, va trebui rezolvat separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)