### PR TITLE
[FIX] l10n_ro_stock_picking_report: sudo valuation layers in consume …

### DIFF
--- a/l10n_ro_stock_picking_report/__manifest__.py
+++ b/l10n_ro_stock_picking_report/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Romania - Terrabit - Picking Reports",
     "summary": "Rapoarte: NIR, aviz, bon consum",
     "license": "AGPL-3",
-    "version": "18.0.1.2.9",
+    "version": "18.0.1.2.10",
     "development_status": "Mature",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",

--- a/l10n_ro_stock_picking_report/views/report_picking.xml
+++ b/l10n_ro_stock_picking_report/views/report_picking.xml
@@ -419,7 +419,7 @@
                                     </td>
                                     <td class="text-end">
                                         <t t-set="line_value" t-value="0.0" />
-                                        <t t-foreach="move.stock_valuation_layer_ids" t-as="valuation_line">
+                                        <t t-foreach="move.sudo().stock_valuation_layer_ids" t-as="valuation_line">
                                             <t t-set="line_value" t-value="line_value-valuation_line.value" />
                                         </t>
                                         <span


### PR DESCRIPTION
…voucher report

The consume voucher report (report_consume_voucher template) read move.stock_valuation_layer_ids directly in QWeb. Since stock.valuation.layer is restricted to the Stock / Administrator group, any user without that group got an AccessError ("Nu aveți permisiunea de a accesa înregistrările 'Nivel evaluare stoc'") when printing the document.

This mirrors the earlier reception-report fix (commit bba9a11): the value is only needed for display, so it is read with sudo() to let standard Inventory users print the report without granting them full valuation-layer access.

- views/report_picking.xml: move.stock_valuation_layer_ids -> move.sudo().stock_valuation_layer_ids
- __manifest__.py: bump version 18.0.1.2.9 -> 18.0.1.2.10