### PR TITLE
[IMP] l10n_ro_efactura_enhancement: skip non-RO customers in SPV and avoid double email

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.2.14",
+    "version": "18.0.0.2.16",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -17,10 +17,12 @@ class AccountMove(models.Model):
 
     # l10n_ro_edi_state = fields.Selection( selection_add=[ ('invoice_sending_failed', 'Error')])
 
-    # Tracks whether the customer invoice email has already been sent after the
-    # SPV validated the invoice. The email is sent only once, after validation
-    # (not at upload time), so a rejected/retried invoice never emails the
-    # customer repeatedly.
+    # Tracks whether the customer invoice email has already been sent, so it is
+    # sent at most once. It is set both when the SPV fetch-status cron emails
+    # the invoice after validation AND when the invoice is emailed through
+    # account.move.send by any other path (notably the operator's manual
+    # "Send & Print"). This prevents a double email: one manual send by the
+    # operator and another by the cron after the SPV validates the invoice.
     l10n_ro_spv_validated_email_sent = fields.Boolean(
         string="Email factură trimis după validare SPV",
         copy=False,

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,27 @@
+## 18.0.0.2.16 (2026-06-24)
+
+- **No more double customer email.** Previously an invoice could be emailed
+  twice: once by the operator's manual "Send & Print" at posting time, and
+  again by the SPV fetch-status cron after the SPV validated it (the
+  `l10n_ro_spv_validated_email_sent` flag was only set by the cron, so a manual
+  send went unnoticed). `account.move.send._send_mails` is now extended to set
+  the flag for every invoice actually emailed to the customer through any path,
+  so the post-validation cron skips invoices the operator already emailed. The
+  SPV upload path uses `sending_methods={"manual"}` (no email), so cron-only
+  invoices are still emailed once after validation.
+
+## 18.0.0.2.15 (2026-06-24)
+
+- **Foreign-customer invoices are no longer uploaded to the SPV via Send &
+  Print.** The core `_is_ro_edi_applicable` only checks the issuing company is
+  Romanian (`country_code == 'RO'`), so the standard Send & Print wizard would
+  upload invoices issued to foreign customers (e.g. Shopify HU) to the SPV and
+  later re-email the customer after validation. The check now also excludes
+  invoices whose commercial partner has a country explicitly set to something
+  other than RO, matching the existing filter on the auto-send cron and
+  `action_send_to_spv_only`. Partners without a country are left untouched to
+  avoid regressions on domestic B2C invoices.
+
 ## 18.0.0.2.14 (2026-06-18)
 
 - **SPV cron report no longer falls back to the company email.** Recipients

--- a/l10n_ro_efactura_enhancement/wizard/account_move_send.py
+++ b/l10n_ro_efactura_enhancement/wizard/account_move_send.py
@@ -9,6 +9,44 @@ _logger = logging.getLogger(__name__)
 class AccountMoveSend(models.AbstractModel):
     _inherit = "account.move.send"
 
+    @api.model
+    def _is_ro_edi_applicable(self, move):
+        # EXTENDS 'l10n_ro_edi'
+        # The core check only verifies the issuing company is Romanian
+        # (``move.country_code == 'RO'``), so the standard "Send & Print"
+        # wizard would also upload invoices issued to foreign customers
+        # (e.g. Shopify HU) to the SPV. Exclude invoices whose commercial
+        # partner has a country explicitly set to something other than RO.
+        # Partners without a country are left untouched to avoid regressions
+        # on domestic B2C invoices that lack the country on the contact.
+        partner_country = move.commercial_partner_id.country_id
+        if partner_country and partner_country.code != "RO":
+            return False
+        return super()._is_ro_edi_applicable(move)
+
+    def _send_mails(self, moves_data):
+        # EXTENDS 'account'
+        res = super()._send_mails(moves_data)
+        # Mark every invoice that was actually emailed to the customer through
+        # account.move.send so the SPV fetch-status cron never emails it a
+        # second time after validation. This covers the operator's manual
+        # "Send & Print" (email at posting time) as well as our own
+        # post-validation email. The SPV upload path uses
+        # sending_methods={"manual"} (no email), so it never reaches here and
+        # the cron still emails those invoices once, after validation.
+        # We mirror the recipient condition used by the core loop above so we
+        # only flag invoices that truly had an email sent.
+        emailed = self.env["account.move"].browse(
+            move.id
+            for move, move_data in moves_data.items()
+            if move.move_type in ("out_invoice", "out_refund")
+            and (move.partner_id.email or move_data.get("mail_partner_ids"))
+        )
+        emailed = emailed.filtered(lambda m: not m.l10n_ro_spv_validated_email_sent)
+        if emailed:
+            emailed.l10n_ro_spv_validated_email_sent = True
+        return res
+
     def _get_alerts(self, moves, moves_data):
         alerts = super()._get_alerts(moves, moves_data)
         _logger.info(f"alerts: {alerts}")


### PR DESCRIPTION
## Context

Pornind de la factura **PTCHU107977** (companie RO, client din Ungaria, serie Shopify HU): a fost **încărcată în SPV** și **trimisă pe email de două ori**. Două probleme distincte, rezolvate aici.

## 1. Facturile către clienți non-RO nu mai ajung în SPV prin Send & Print

`l10n_ro_edi._is_ro_edi_applicable` verifică doar că **firma emitentă** e română (`country_code == 'RO'`), deci wizard-ul standard *Send & Print* încărca în SPV și facturile către clienți din afara RO. Override-ul exclude acum facturile al căror `commercial_partner_id` are țara setată explicit ≠ RO — consecvent cu filtrul deja existent pe cron-ul de auto-send și pe `action_send_to_spv_only`. Partenerii **fără** țară rămân neatinși (nu regresăm B2C-ul intern fără țară pe contact).

## 2. Fără dublă trimitere pe email

Factura putea fi trimisă pe email de două ori: o dată manual de operator (*Send & Print* la postare) și încă o dată de cron-ul de fetch-status după validarea SPV (`l10n_ro_spv_validated_email_sent` se seta **doar** din cron). Acum `account.move.send._send_mails` setează flag-ul pentru **orice** factură trimisă efectiv pe email către client, pe orice cale, deci cron-ul post-validare sare peste cele deja trimise de operator. Calea de upload în SPV folosește `sending_methods={"manual"}` (fără email), deci facturile gestionate doar de cron primesc tot un singur email, după validare.

| Scenariu | Email la trimitere | Flag | Cron după validare |
|---|---|---|---|
| Operator Send & Print (cu email) | 1× | ✅ la trimitere | sărit → fără al doilea email |
| Doar upload SPV (cron, `manual`) | — | — | 1 email după validare |
| Cron trimite emailul de validare | 1× | ✅ | n/a |

## Testare

- `-u l10n_ro_efactura_enhancement` pe baza locală `ptc18` → încărcare curată.
- Verificat în `odoo shell`: `_is_ro_edi_applicable` întoarce `False` pentru factură HU cu stare goală (PTCHU108211) și `True` pentru client RO / partener fără țară; ambele override-uri prezente în MRO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)