### PR TITLE
[IMP] l10n_ro_stock_account_landed_cost_account: optional intermediary account for landed cost

### DIFF
--- a/l10n_ro_stock_account_landed_cost_account/__manifest__.py
+++ b/l10n_ro_stock_account_landed_cost_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting Landed Cost Account",
-    "version": "18.0.0.0.3",
+    "version": "18.0.1.0.0",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting Landed Cost account determination",
@@ -10,6 +10,10 @@
     "depends": [
         "stock_landed_costs",
         "l10n_ro_stock_account",
+        "l10n_ro_config",
+    ],
+    "data": [
+        "views/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
     "installable": True,

--- a/l10n_ro_stock_account_landed_cost_account/models/__init__.py
+++ b/l10n_ro_stock_account_landed_cost_account/models/__init__.py
@@ -1,2 +1,4 @@
 from . import account_move
 from . import stock_landed_cost
+from . import res_company
+from . import res_config_settings

--- a/l10n_ro_stock_account_landed_cost_account/models/res_company.py
+++ b/l10n_ro_stock_account_landed_cost_account/models/res_company.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2026 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    l10n_ro_landed_cost_intermediary_account_id = fields.Many2one(
+        "account.account",
+        string="Landed Cost Intermediary Account",
+        help="Technical intermediary account used to transfer service costs into "
+        "products on landed cost validation (e.g. 482.99). When set, a landed cost "
+        "entry that would credit a class 6 (expense) account is routed through this "
+        "account, producing two clean balanced notes (stock valuation = intermediary "
+        "account and intermediary account = class 6) instead of a direct stock "
+        "valuation = class 6 entry. Class 609 is never rerouted. Leave empty to keep "
+        "the standard behaviour.",
+    )

--- a/l10n_ro_stock_account_landed_cost_account/models/res_config_settings.py
+++ b/l10n_ro_stock_account_landed_cost_account/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    l10n_ro_landed_cost_intermediary_account_id = fields.Many2one(
+        related="company_id.l10n_ro_landed_cost_intermediary_account_id",
+        readonly=False,
+    )

--- a/l10n_ro_stock_account_landed_cost_account/models/stock_landed_cost.py
+++ b/l10n_ro_stock_account_landed_cost_account/models/stock_landed_cost.py
@@ -32,6 +32,35 @@ class AdjustmentLines(models.Model):
                 self.env["account.account"].browse(already_out_account_id)
             ).id
 
-        return super()._create_account_move_line(
+        lines = super()._create_account_move_line(
             move, credit_account_id, debit_account_id, qty_out, already_out_account_id
         )
+        return self._l10n_ro_route_class6_through_intermediary(lines)
+
+    def _l10n_ro_route_class6_through_intermediary(self, lines):
+        """Route class 6 (expense) credit lines through the technical intermediary
+        account, so a landed cost move keeps two clean balanced notes
+        (stock valuation = intermediary account and intermediary account = class 6)
+        instead of crediting a class 6 account directly. Class 609 is never
+        rerouted. When no intermediary account is configured on the company, the
+        standard behaviour is preserved."""
+        intermediary_account = self.cost_id.company_id.l10n_ro_landed_cost_intermediary_account_id
+        if not intermediary_account:
+            return lines
+
+        new_lines = []
+        for command in lines:
+            vals = command[2]
+            account = self.env["account.account"].browse(vals.get("account_id"))
+            credit = vals.get("credit") or 0.0
+            is_class_6 = account.code and account.code.startswith("6") and not account.code.startswith("609")
+            if is_class_6 and credit:
+                # 1) original credit line -> intermediary account (pairs with the stock valuation debit)
+                new_lines.append([0, 0, dict(vals, account_id=intermediary_account.id)])
+                # 2) intermediary account on debit (pairs with the class 6 credit below)
+                new_lines.append([0, 0, dict(vals, account_id=intermediary_account.id, credit=0.0, debit=credit)])
+                # 3) class 6 account credited against the intermediary account
+                new_lines.append([0, 0, dict(vals, account_id=account.id)])
+            else:
+                new_lines.append(command)
+        return new_lines

--- a/l10n_ro_stock_account_landed_cost_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account_landed_cost_account/readme/HISTORY.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 18.0.1.0.0
+
+- Added an optional **Landed Cost Intermediary Account** company setting (Accounting /
+  Romania settings). This is the technical intermediary account (e.g. `482.99`)
+  used to transfer service costs into products on landed cost validation. When set,
+  a landed cost entry that would credit a class 6 (expense) account is routed
+  through this account, producing two clean balanced notes
+  (`stock valuation = intermediary account` and `intermediary account = class 6`) instead
+  of a direct `stock valuation = class 6` entry. This keeps the notes acceptable
+  for the SAGA export. Class `609` is never rerouted. When the setting is empty,
+  the standard behaviour is unchanged.
+- Added dependency on `l10n_ro_config` (Romania settings block).

--- a/l10n_ro_stock_account_landed_cost_account/tests/__init__.py
+++ b/l10n_ro_stock_account_landed_cost_account/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_landed_cost_intermediary

--- a/l10n_ro_stock_account_landed_cost_account/tests/test_landed_cost_intermediary.py
+++ b/l10n_ro_stock_account_landed_cost_account/tests/test_landed_cost_intermediary.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2026 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import Form, tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestLandedCostIntermediary(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        def account(code, name, account_type="asset_current", reconcile=False):
+            acc = cls.env["account.account"].search([("code", "=", code)], limit=1)
+            if not acc:
+                acc = cls.env["account.account"].create(
+                    {"name": name, "code": code, "account_type": account_type, "reconcile": reconcile}
+                )
+            return acc
+
+        cls.account_expense = account("607000", "Expense", "expense")
+        cls.account_income = account("707000", "Income", "income")
+        cls.account_input = account("371000.i", "Input")
+        cls.account_output = account("371000.o", "Output")
+        cls.account_valuation = account("371000", "Valuation")
+        cls.intermediary_account = account("482099", "Decontari costuri aditionale")
+
+        cls.stock_journal = cls.env["account.journal"].search([("code", "=", "STJ")], limit=1)
+        if not cls.stock_journal:
+            cls.stock_journal = cls.env["account.journal"].create(
+                {"name": "Stock Journal", "code": "STJ", "type": "general"}
+            )
+
+        cls.category = cls.env["product.category"].create(
+            {
+                "name": "Marfa",
+                "property_cost_method": "fifo",
+                "property_valuation": "real_time",
+                "property_account_income_categ_id": cls.account_income.id,
+                "property_account_expense_categ_id": cls.account_expense.id,
+                "property_stock_account_input_categ_id": cls.account_input.id,
+                "property_stock_account_output_categ_id": cls.account_output.id,
+                "property_stock_valuation_account_id": cls.account_valuation.id,
+                "property_stock_journal": cls.stock_journal.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {"name": "Product A", "is_storable": True, "categ_id": cls.category.id}
+        )
+        cls.cost_product = cls.env["product.product"].create(
+            {"name": "Transport", "type": "service", "landed_cost_ok": True}
+        )
+        cls.vendor = cls.env["res.partner"].create({"name": "vendor_lc"})
+
+    def _receive_product(self):
+        po = Form(self.env["purchase.order"])
+        po.partner_id = self.vendor
+        with po.order_line.new() as po_line:
+            po_line.product_id = self.product
+            po_line.product_qty = 10
+            po_line.price_unit = 100
+        po = po.save()
+        po.button_confirm()
+        picking = po.picking_ids[0]
+        picking.move_line_ids.write({"quantity": 10.0})
+        picking.button_validate()
+        return picking
+
+    def _create_landed_cost(self, picking):
+        landed = self.env["stock.landed.cost"].create(
+            {
+                "picking_ids": [(6, 0, picking.ids)],
+                "account_journal_id": self.stock_journal.id,
+                "cost_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.cost_product.id,
+                            "price_unit": 100.0,
+                            "split_method": "by_quantity",
+                            "account_id": self.account_expense.id,
+                        },
+                    )
+                ],
+            }
+        )
+        landed.compute_landed_cost()
+        landed.button_validate()
+        return landed
+
+    def test_intermediary_account_reroutes_class6(self):
+        """With the intermediary account configured, the class 6 account is not
+        credited against the stock valuation directly; the intermediary account
+        nets to zero."""
+        self.env.company.l10n_ro_landed_cost_intermediary_account_id = self.intermediary_account
+        landed = self._create_landed_cost(self._receive_product())
+        move = landed.account_move_id
+        self.assertTrue(move, "Landed cost account move should be created")
+
+        intermediary_lines = move.line_ids.filtered(lambda line: line.account_id == self.intermediary_account)
+        self.assertTrue(intermediary_lines, "Intermediary account must appear in the move")
+        balance = sum(intermediary_lines.mapped("debit")) - sum(intermediary_lines.mapped("credit"))
+        self.assertAlmostEqual(balance, 0.0, places=2, msg="Intermediary account must net to zero")
+
+        class6_lines = move.line_ids.filtered(lambda line: line.account_id == self.account_expense)
+        self.assertTrue(class6_lines, "Class 6 account must still be present in the move")
+
+    def test_no_intermediary_account_keeps_standard(self):
+        """Without the intermediary account, the standard behaviour is preserved
+        (no intermediary account line, class 6 credited directly)."""
+        self.env.company.l10n_ro_landed_cost_intermediary_account_id = False
+        landed = self._create_landed_cost(self._receive_product())
+        move = landed.account_move_id
+        self.assertTrue(move, "Landed cost account move should be created")
+        intermediary_lines = move.line_ids.filtered(lambda line: line.account_id == self.intermediary_account)
+        self.assertFalse(intermediary_lines, "Intermediary account must not appear when not configured")

--- a/l10n_ro_stock_account_landed_cost_account/views/res_config_settings_views.xml
+++ b/l10n_ro_stock_account_landed_cost_account/views/res_config_settings_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.l10n_ro_stock_account_landed_cost_account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_ro_config.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//block[@id='ro_accounting_setting_container']" position="inside">
+                <setting
+                    id="l10n_ro_landed_cost_intermediary_account"
+                    string="Landed Cost Intermediary Account"
+                    help="Technical intermediary account used to transfer service costs into products on landed cost validation (e.g. 482.99). When set, entries that would credit a class 6 account are routed through it, producing two clean balanced notes. Leave empty to keep the standard behaviour."
+                >
+                    <field name="l10n_ro_landed_cost_intermediary_account_id" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Context

Helpdesk #8275 (DATUS/Agropiesa): on Romanian accounting, class 6 (expense) accounts must stay on the **debit** side. When validating a landed cost (additional cost), the standard flow posts `371.xx = 624` — i.e. it **credits** a class 6 account, which breaks the SAGA export ("Nu s-au găsit conturile corespunzătoare pentru nota contabilă").

## What this PR does

Adds an optional **Landed Cost Intermediary Account** company setting (`l10n_ro_landed_cost_intermediary_account_id`), exposed in the Romania accounting settings block. It is the technical intermediary account (e.g. `482.99`) used to transfer service costs into products on landed cost validation.

When set, a landed cost entry that would credit a class 6 account is routed through this account, producing **two clean balanced notes**:

```
371.xx = 482.99
482.99 = 624
```

instead of a direct `371.xx = 624` entry — keeping the journal entries acceptable for the SAGA export.

- Class **609** is never rerouted (it is a liability-type account).
- When the setting is **empty**, the standard behaviour is unchanged (zero impact on existing installs).

## Notes / limitations

Odoo normalizes the debit/credit sign **per move** (`balance = debit − credit`), so class 6 still ends up technically on the credit side of the second note — the entry pair is clean and balanced, which resolves the SAGA structure. Keeping class 6 strictly on debit (negative) would require per-line storno handling and is out of scope here.

## Tests

`tests/test_landed_cost_intermediary.py`:
- `test_intermediary_account_reroutes_class6` — intermediary account appears and nets to zero; class 6 still present.
- `test_no_intermediary_account_keeps_standard` — no intermediary line when the setting is empty.

Both pass on a fresh DB (`0 failed, 0 error(s) of 2 tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)