### PR TITLE
[FIX] l10n_ro_efactura_enhancement: prevent duplicate SPV uploads

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.2.16",
+    "version": "18.0.0.3.0",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import timedelta
 
+import requests
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -27,6 +29,21 @@ class AccountMove(models.Model):
         string="Email factură trimis după validare SPV",
         copy=False,
         default=False,
+    )
+
+    # Set when a send to the SPV ended in an uncertain state (typically a
+    # response timeout from ANAF): the upload MAY have reached the SPV even
+    # though Odoo did not record an index. Such an invoice must NOT be
+    # re-sent automatically by the auto-send cron, otherwise a second upload
+    # is created at ANAF for the same invoice (duplicate). It requires a
+    # manual check in the SPV and is cleared once resolved.
+    l10n_ro_edi_send_uncertain = fields.Boolean(
+        string="Trimitere SPV incertă (verificare manuală)",
+        copy=False,
+        default=False,
+        help="Trimiterea către SPV s-a încheiat fără răspuns de la ANAF "
+        "(timeout). Încărcarea poate să fi ajuns totuși în SPV. Factura nu se "
+        "retrimite automat — verificați în SPV și debifați după clarificare.",
     )
 
     def check_partner(self, partner):
@@ -156,6 +173,11 @@ class AccountMove(models.Model):
                 ("date", ">=", fields.Date.today() - timedelta(days=days + delay_days)),
                 ("commercial_partner_id.country_id.code", "=", "RO"),
                 ("l10n_ro_edi_state", "=", False),
+                # Skip invoices whose previous send ended in an uncertain state
+                # (response timeout): the upload may have reached the SPV, so an
+                # automatic re-send would create a duplicate at ANAF. These need
+                # a manual check in the SPV before being sent again.
+                ("l10n_ro_edi_send_uncertain", "=", False),
                 ("company_id", "=", company.id),
             ]
 
@@ -355,7 +377,64 @@ class AccountMove(models.Model):
         )
 
     def _l10n_ro_edi_send_invoice(self, xml_data):
-        return super(AccountMove, self.with_context(active_id=self.id))._l10n_ro_edi_send_invoice(xml_data)
+        self.ensure_one()
+
+        # Idempotency guard: never re-upload an invoice that already has a
+        # successful upload in the SPV. The ANAF 'upload' endpoint is not
+        # idempotent (each call creates a new index_incarcare for the same
+        # invoice), so a second trigger (cron + manual Send & Print at almost
+        # the same time, or a retry) would create a duplicate at ANAF.
+        already_sent = self.l10n_ro_edi_document_ids.filtered(
+            lambda d: d.state in ("invoice_sent", "invoice_validated")
+        )
+        if already_sent or self.l10n_ro_edi_index:
+            index = self.l10n_ro_edi_index or already_sent[:1].key_loading
+            _logger.warning(
+                "E-Factura %s deja încărcată în SPV (index=%s); se evită re-trimiterea.",
+                self.name,
+                index,
+            )
+            self.message_post(
+                body=_(
+                    "Trimiterea către SPV a fost evitată: factura are deja o "
+                    "încărcare în SPV (index de încărcare %s). Nu se retrimite, "
+                    "pentru a nu crea un duplicat la ANAF.",
+                    index,
+                )
+            )
+            return
+
+        try:
+            res = super(AccountMove, self.with_context(active_id=self.id))._l10n_ro_edi_send_invoice(xml_data)
+        except requests.Timeout:
+            # Response timeout from ANAF: the upload MAY have reached the SPV
+            # even though we did not receive the index. We must NOT mark this as
+            # a retriable failure (the auto-send cron would re-upload it and
+            # create a duplicate). Flag it for a manual SPV check instead.
+            self.l10n_ro_edi_send_uncertain = True
+            _logger.warning(
+                "Timeout la trimiterea E-Factura %s; marcată pentru verificare manuală în SPV.",
+                self.name,
+            )
+            self.message_post(
+                body=_(
+                    "Trimiterea către SPV a expirat (timeout) fără răspuns de la "
+                    "ANAF. Încărcarea poate să fi ajuns totuși în SPV. Factura NU "
+                    "se retrimite automat — verificați în SPV dacă a fost primită: "
+                    "dacă da, completați indexul de încărcare; dacă nu, debifați "
+                    "„Trimitere SPV incertă” și reluați trimiterea."
+                )
+            )
+            return
+        # A successful send resolves any previous uncertain state.
+        if self.l10n_ro_edi_send_uncertain:
+            self.l10n_ro_edi_send_uncertain = False
+        return res
+
+    def action_l10n_ro_edi_clear_send_uncertain(self):
+        """Clear the 'uncertain send' flag after a manual SPV check, so the
+        invoice can be picked up again by the normal send flow."""
+        self.write({"l10n_ro_edi_send_uncertain": False})
 
     @api.model
     def _cron_account_move_send(self, job_count=10):

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,4 +1,21 @@
-## 18.0.0.2.16 (2026-06-24)
+## 18.0.0.3.0 (2026-06-26)
+
+- **Protecție anti-duplicat la trimiterea în SPV.** O factură putea ajunge de
+  două ori la ANAF (două `index_incarcare` pentru același număr de factură),
+  fie printr-o dublă declanșare (cron de auto-send + „Send & Print" manual
+  aproape simultan), fie după un timeout la răspunsul ANAF (încărcarea ajungea
+  la SPV, dar Odoo nu reținea indexul și o re-trimitea). Două măsuri:
+  - **Gardă de idempotență** în `_l10n_ro_edi_send_invoice`: dacă factura are
+    deja un document `invoice_sent`/`invoice_validated` sau un index de
+    încărcare, trimiterea este evitată (mesaj în chatter), pentru a nu crea un
+    al doilea upload la ANAF (API-ul `upload` nu este idempotent).
+  - **Tratarea timeout-ului** (`requests.Timeout`, inclusiv `ReadTimeout`, care
+    în core nu era prins): trimiterea nu mai e marcată drept eroare
+    re-trimitabilă; factura este marcată `l10n_ro_edi_send_uncertain` și
+    **exclusă din cronul de auto-send**, cu un mesaj care cere verificare
+    manuală în SPV. Un buton pe factură debifează marcajul după clarificare.
+
+
 
 - **No more double customer email.** Previously an invoice could be emailed
   twice: once by the operator's manual "Send & Print" at posting time, and

--- a/l10n_ro_efactura_enhancement/readme/ROADMAP.md
+++ b/l10n_ro_efactura_enhancement/readme/ROADMAP.md
@@ -1,5 +1,18 @@
 # Roadmap
 
+## Planned
+
+- **Reconciliere automată a trimiterilor incerte cu lista de mesaje SPV.**
+  Garda actuală oprește re-trimiterea automată după un timeout
+  (`l10n_ro_edi_send_uncertain`), dar verificarea „a ajuns sau nu factura la
+  SPV?" rămâne manuală. Pas următor: la fetch-status, dacă există stiva de
+  descărcare mesaje SPV (`l10n.ro.message.spv`), să se caute automat o
+  încărcare existentă pentru factura incertă (potrivire pe CIF beneficiar +
+  sumă + dată, eventual și pe numărul facturii din XML-ul descărcat) și să se
+  adopte `index_incarcare` găsit, în loc de re-trimitere. Atenție: metadatele
+  listei ANAF nu conțin numărul nostru de factură, deci potrivirea e euristică
+  (nu 100% pentru facturi diferite cu același partener/sumă/zi).
+
 ## Known Bugs to Fix
 
 - **Missing system parameter defaults**: `efactura.get_all_banks` and `efactura.replace_unit_uom`

--- a/l10n_ro_efactura_enhancement/tests/__init__.py
+++ b/l10n_ro_efactura_enhancement/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_cron_fix
 from . import test_spv_actions
+from . import test_spv_anti_duplicate

--- a/l10n_ro_efactura_enhancement/tests/test_spv_anti_duplicate.py
+++ b/l10n_ro_efactura_enhancement/tests/test_spv_anti_duplicate.py
@@ -8,8 +8,10 @@ import requests
 from odoo import fields
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 SEND_METHOD = "odoo.addons.l10n_ro_edi.models.ciusro_document" ".L10nRoEdiDocument._request_ciusro_send_invoice"
+LOGGER = "odoo.addons.l10n_ro_efactura_enhancement.models.account_move"
 
 
 @tagged("post_install", "-at_install")
@@ -42,6 +44,7 @@ class TestSpvAntiDuplicate(TransactionCase):
         invoice.action_post()
         return invoice
 
+    @mute_logger(LOGGER)
     def test_timeout_flags_uncertain_and_blocks_resend(self):
         """Un timeout la trimitere marchează factura ca incertă, fără document
         'invoice_sent', și o exclude din cronul de auto-send."""
@@ -64,6 +67,7 @@ class TestSpvAntiDuplicate(TransactionCase):
         )
         self.assertNotIn(invoice, candidates, "Factura incertă nu trebuie auto-retrimisă")
 
+    @mute_logger(LOGGER)
     def test_idempotency_guard_skips_when_index_present(self):
         """Dacă factura are deja index de încărcare, nu se mai trimite."""
         invoice = self._create_invoice()
@@ -72,6 +76,7 @@ class TestSpvAntiDuplicate(TransactionCase):
             invoice._l10n_ro_edi_send_invoice("<Invoice/>")
         mock_send.assert_not_called()
 
+    @mute_logger(LOGGER)
     def test_idempotency_guard_skips_when_sent_document_present(self):
         """Dacă factura are deja un document validat, nu se mai trimite."""
         invoice = self._create_invoice()

--- a/l10n_ro_efactura_enhancement/tests/test_spv_anti_duplicate.py
+++ b/l10n_ro_efactura_enhancement/tests/test_spv_anti_duplicate.py
@@ -1,0 +1,95 @@
+# ©  2026 Terrabit
+# See README.rst file on addons root folder for license details
+
+from unittest.mock import patch
+
+import requests
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+SEND_METHOD = "odoo.addons.l10n_ro_edi.models.ciusro_document" ".L10nRoEdiDocument._request_ciusro_send_invoice"
+
+
+@tagged("post_install", "-at_install")
+class TestSpvAntiDuplicate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        # pre_send check requires an access token to proceed to the upload
+        cls.company.l10n_ro_edi_access_token = "TESTTOKEN"
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner RO",
+                "country_id": cls.env.ref("base.ro").id,
+                "state_id": cls.env.ref("base.RO_B").id,
+                "city": "Bucuresti",
+                "street": "Str. Test 1",
+            }
+        )
+        cls.product = cls.env["product.product"].create({"name": "Test Product"})
+
+    def _create_invoice(self):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "invoice_line_ids": [(0, 0, {"product_id": self.product.id, "quantity": 1, "price_unit": 100})],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def test_timeout_flags_uncertain_and_blocks_resend(self):
+        """Un timeout la trimitere marchează factura ca incertă, fără document
+        'invoice_sent', și o exclude din cronul de auto-send."""
+        invoice = self._create_invoice()
+        with patch(SEND_METHOD, side_effect=requests.ReadTimeout("timeout")):
+            invoice._l10n_ro_edi_send_invoice("<Invoice/>")
+
+        self.assertTrue(invoice.l10n_ro_edi_send_uncertain, "Factura trebuie marcată incertă")
+        self.assertFalse(
+            invoice.l10n_ro_edi_document_ids.filtered(lambda d: d.state == "invoice_sent"),
+            "Nu trebuie să existe document 'invoice_sent' după timeout",
+        )
+        # cronul de auto-send selectează state=False + uncertain=False -> exclusă
+        candidates = self.env["account.move"].search(
+            [
+                ("l10n_ro_edi_state", "=", False),
+                ("l10n_ro_edi_send_uncertain", "=", False),
+                ("id", "=", invoice.id),
+            ]
+        )
+        self.assertNotIn(invoice, candidates, "Factura incertă nu trebuie auto-retrimisă")
+
+    def test_idempotency_guard_skips_when_index_present(self):
+        """Dacă factura are deja index de încărcare, nu se mai trimite."""
+        invoice = self._create_invoice()
+        invoice.l10n_ro_edi_index = "6520851057"
+        with patch(SEND_METHOD) as mock_send:
+            invoice._l10n_ro_edi_send_invoice("<Invoice/>")
+        mock_send.assert_not_called()
+
+    def test_idempotency_guard_skips_when_sent_document_present(self):
+        """Dacă factura are deja un document validat, nu se mai trimite."""
+        invoice = self._create_invoice()
+        self.env["l10n_ro_edi.document"].create(
+            {
+                "invoice_id": invoice.id,
+                "state": "invoice_validated",
+                "key_loading": "6520851057",
+                "datetime": fields.Datetime.now(),
+            }
+        )
+        with patch(SEND_METHOD) as mock_send:
+            invoice._l10n_ro_edi_send_invoice("<Invoice/>")
+        mock_send.assert_not_called()
+
+    def test_clear_uncertain(self):
+        """Butonul de resetare debifează marcajul incert."""
+        invoice = self._create_invoice()
+        invoice.l10n_ro_edi_send_uncertain = True
+        invoice.action_l10n_ro_edi_clear_send_uncertain()
+        self.assertFalse(invoice.l10n_ro_edi_send_uncertain)

--- a/l10n_ro_efactura_enhancement/views/account_move.xml
+++ b/l10n_ro_efactura_enhancement/views/account_move.xml
@@ -6,6 +6,22 @@
         <field name="type">form</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <field name="l10n_ro_edi_send_uncertain" invisible="1" />
+                <button
+                    name="action_l10n_ro_edi_clear_send_uncertain"
+                    type="object"
+                    string="SPV: marchează verificat"
+                    invisible="not l10n_ro_edi_send_uncertain"
+                    help="Debifează „Trimitere SPV incertă” după ce ați verificat în SPV dacă factura a fost primită."
+                />
+            </xpath>
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning text-center" role="alert" invisible="not l10n_ro_edi_send_uncertain">
+                    Trimiterea către SPV a expirat fără răspuns de la ANAF. Verificați în SPV dacă factura a
+                    fost primită înainte de a o retrimite, pentru a evita un duplicat.
+                </div>
+            </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='name']" position="after">
                 <field name="l10n_ro_label_length" optional="hide" />
             </xpath>


### PR DESCRIPTION
## Context

Tichet helpdesk **#8896** (RIDACON TEX). Factura client **CPNCC/2026/000913** a ajuns de **două ori** la ANAF, cu două `index_incarcare` diferite (`6520851057` + `6478633080`), pentru același număr de factură. În Odoo apărea o singură trimitere, fiindcă partea Enterprise `l10n_ro_edi` reținuse doar un index.

## Cauză (verificată în cod)

1. **Lipsă gardă de idempotență**: `_l10n_ro_edi_send_invoice` face `l10n_ro_edi_index = False` și trimite, fără să verifice dacă factura are deja o încărcare. O dublă declanșare (cron `_cron_l10n_ro_edi_auto_send` + „Send & Print" manual aproape simultan) urcă de două ori — API-ul ANAF `upload` **nu e idempotent**.
2. **Timeout neprins**: în core `make_efactura_request` prinde doar `ConnectionError`/`TooManyRedirects`, **nu** `requests.ReadTimeout`. La un răspuns ANAF întârziat >60s, încărcarea ajunge la SPV dar Odoo dă rollback și o re-trimite → duplicat.

## Ce face acest PR (în `l10n_ro_efactura_enhancement`, fără patch pe core)

- **Gardă de idempotență** în `_l10n_ro_edi_send_invoice`: dacă factura are deja un document `invoice_sent`/`invoice_validated` sau un index, trimiterea este evitată (mesaj în chatter).
- **Tratarea `requests.Timeout`**: factura este marcată `l10n_ro_edi_send_uncertain` și **exclusă din cronul de auto-send** (nu mai e re-trimisă automat), cu mesaj care cere verificare manuală în SPV. Buton pe factură + banner de avertizare pentru a debifa marcajul după clarificare.
- Câmp nou `l10n_ro_edi_send_uncertain` (Boolean, `copy=False`, default False — fără migrare necesară).

## Limitare / follow-up (ROADMAP)

Verificarea „a ajuns sau nu la SPV?" rămâne **manuală**. Pasul următor (notat în ROADMAP) e reconcilierea automată a trimiterilor incerte cu lista de mesaje SPV (`l10n.ro.message.spv`), pe CIF beneficiar + sumă + dată — euristică, fiindcă metadatele ANAF nu conțin numărul nostru de factură.

## Testare

4 teste noi (`tests/test_spv_anti_duplicate.py`), toate trec pe `test_efact` (Odoo 18):
- timeout → marchează `uncertain`, fără document `invoice_sent`, exclusă din auto-send;
- gardă idempotență cu index prezent → nu se mai trimite;
- gardă idempotență cu document validat prezent → nu se mai trimite;
- butonul de resetare debifează marcajul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
