### PR TITLE
[DOC] l10n_ro_efactura_enhancement: note SPV anti-duplicate is native in Odoo 19

### DIFF
--- a/l10n_ro_efactura_enhancement/readme/DESCRIPTION.md
+++ b/l10n_ro_efactura_enhancement/readme/DESCRIPTION.md
@@ -10,6 +10,7 @@ The l10n_ro_efactura_enhancement module extends the standard Romanian e-Invoicin
     - Cron job for **fetching status** updates from SPV for sent invoices.
     - **Server action "Trimite in SPV"**: Allows sending selected invoices directly to SPV from the invoice list view, without triggering email sending.
     - **Configuration option**: A setting in the Accounting configuration page controls whether the automatic SPV cron job suppresses email sending (sends only to SPV).
+    - **Anti-duplicate protection when sending to SPV** (idempotency guard + response-timeout handling). NOTE: this replicates behaviour that is **native in Odoo 19 standard** (`l10n_ro_edi`): the `invoice_not_indexed` state, the pre-send "already sent" guard, and "Synchronise to SPV" recovery. On Odoo 19 this part of the enhancement is no longer needed for the duplicate case.
 - **Data Truncation and Sanitization**:
     - Truncates product names to 100 characters and descriptions to 200 characters to ensure compliance with UBL standards.
     - Truncates notes to 300 characters.

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -14,6 +14,11 @@
     re-trimitabilă; factura este marcată `l10n_ro_edi_send_uncertain` și
     **exclusă din cronul de auto-send**, cu un mesaj care cere verificare
     manuală în SPV. Un buton pe factură debifează marcajul după clarificare.
+  - **Notă:** această protecție este un *backport* al comportamentului **nativ
+    din Odoo 19 standard** (`l10n_ro_edi`): pe 19 există deja starea
+    `invoice_not_indexed`, garda de pre-send „already sent" și recuperarea prin
+    „Synchronise to SPV". Pe Odoo 19 dezvoltarea de față nu mai este necesară
+    pentru cazul duplicatelor.
 
 
 


### PR DESCRIPTION
Notează în documentația modulului (DESCRIPTION + HISTORY) că protecția anti-duplicat la trimiterea în SPV (PR #437) este un **backport** al comportamentului **nativ din Odoo 19 standard** (`l10n_ro_edi`): starea `invoice_not_indexed`, garda de pre-send „already sent" și recuperarea prin „Synchronise to SPV".

Scop: să știm pe viitor că pe Odoo 19 această dezvoltare nu mai e necesară pentru cazul duplicatelor (e acoperită nativ).

Doar documentație — fără schimbări de cod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)