### PR TITLE
[FIX] l10n_ro_efactura_enhancement: truncate order reference (BT-13) to 200 chars

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.3.0",
+    "version": "18.0.0.3.1",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
@@ -252,6 +252,16 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
                 "cbc:SalesOrderID"
             ]["_text"][:200]
 
+        # Limit purchase order reference (BT-13) to 200 chars (ANAF rule BR-RO-L200)
+        if (
+            document_node.get("cac:OrderReference")
+            and document_node["cac:OrderReference"].get("cbc:ID")
+            and document_node["cac:OrderReference"]["cbc:ID"].get("_text")
+        ):
+            document_node["cac:OrderReference"]["cbc:ID"]["_text"] = document_node["cac:OrderReference"]["cbc:ID"][
+                "_text"
+            ][:200]
+
         if document_node.get("cbc:Note"):
             if isinstance(document_node["cbc:Note"], list):
                 for note in document_node["cbc:Note"]:
@@ -395,11 +405,15 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         return res
 
     def _ubl_add_order_reference_node(self, vals):
-        # linit salesorder names
+        # limit salesorder names (BT-14) and purchase order reference (BT-13) to 200 chars
+        # ANAF rule BR-RO-L200 rejects BT-13/BT-14 longer than 200 characters
         res = super()._ubl_add_order_reference_node(vals)
         order_ref_node = vals.get("document_node", {}).get("cac:OrderReference")
-        if order_ref_node and order_ref_node.get("cbc:SalesOrderID", {}).get("_text"):
-            order_ref_node["cbc:SalesOrderID"]["_text"] = order_ref_node["cbc:SalesOrderID"]["_text"][:200]
+        if order_ref_node:
+            if order_ref_node.get("cbc:SalesOrderID", {}).get("_text"):
+                order_ref_node["cbc:SalesOrderID"]["_text"] = order_ref_node["cbc:SalesOrderID"]["_text"][:200]
+            if order_ref_node.get("cbc:ID", {}).get("_text"):
+                order_ref_node["cbc:ID"]["_text"] = order_ref_node["cbc:ID"]["_text"][:200]
         return res
 
     def _ubl_add_accounting_supplier_party_legal_entity_nodes(self, vals):

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,14 @@
+## 18.0.0.3.1 (2026-06-30)
+
+- **Trunchiere referință comandă (BT-13) la 200 de caractere.** Pe facturile de
+  revânzare cu multe comenzi consolidate, câmpul „Referință client" (`ref`)
+  putea depăși 200 de caractere și ajungea ca atare în `cac:OrderReference/cbc:ID`
+  (BT-13), iar ANAF respingea transmiterea cu eroarea **BR-RO-L200** („Numărul
+  maxim permis de caractere pentru Referința comenzii (BT-13) este 200").
+  Acum BT-13 este limitat la 200 de caractere la generarea XML-ului, simetric
+  cu limitarea deja existentă pe `cbc:SalesOrderID` (BT-14). Modificat în
+  `_add_invoice_header_nodes` (CIUS-RO) și `_ubl_add_order_reference_node` (BIS3).
+
 ## 18.0.0.3.0 (2026-06-26)
 
 - **Protecție anti-duplicat la trimiterea în SPV.** O factură putea ajunge de


### PR DESCRIPTION
## Context

Helpdesk ticket **#8913** (PTC ONLINE) — resale invoices (`PTCDRO*`) could not be transmitted to SPV. ANAF rejected the upload with:

```
[BR-RO-L200] Numărul maxim permis de caractere pentru Referința comenzii (BT-13) este 200.
```

## Root cause

Resale invoices consolidate many order references into the **customer reference** (`ref`) field — e.g. 381 chars on `PTCDRO19820` (87 lines). Odoo's CIUS-RO export maps `invoice.ref` directly into **BT-13** (`cac:OrderReference/cbc:ID`) with no length limit, so any `ref > 200` is rejected by ANAF.

The module already truncated `cbc:SalesOrderID` (BT-14) to 200 chars, but **not** `cbc:ID` (BT-13).

## Fix

Limit BT-13 to 200 chars at XML generation, in both:
- `_add_invoice_header_nodes` (CIUS-RO class)
- `_ubl_add_order_reference_node` (BIS3 class)

Symmetric with the existing BT-14 truncation. Version bump `18.0.0.3.0` → `18.0.0.3.1` + HISTORY entry.

## Impact

9 invoices currently blocked on PTC production will transmit after update, without editing the `ref` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)