### PR TITLE
[FIX] l10n_ro_efactura_enhancement: truncate order reference (BT-13) to 200 chars

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "19.0.0.3.12",
+    "version": "19.0.0.3.13",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
@@ -231,11 +231,15 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         return res
 
     def _ubl_add_order_reference_node(self, vals):
-        # linit salesorder names
+        # limit salesorder names (BT-14) and purchase order reference (BT-13) to 200 chars
+        # ANAF rule BR-RO-L200 rejects BT-13/BT-14 longer than 200 characters
         res = super()._ubl_add_order_reference_node(vals)
         order_ref_node = vals.get("document_node", {}).get("cac:OrderReference")
-        if order_ref_node and order_ref_node.get("cbc:SalesOrderID", {}).get("_text"):
-            order_ref_node["cbc:SalesOrderID"]["_text"] = order_ref_node["cbc:SalesOrderID"]["_text"][:200]
+        if order_ref_node:
+            if order_ref_node.get("cbc:SalesOrderID", {}).get("_text"):
+                order_ref_node["cbc:SalesOrderID"]["_text"] = order_ref_node["cbc:SalesOrderID"]["_text"][:200]
+            if order_ref_node.get("cbc:ID", {}).get("_text"):
+                order_ref_node["cbc:ID"]["_text"] = order_ref_node["cbc:ID"]["_text"][:200]
         return res
 
     def _ubl_add_accounting_supplier_party_legal_entity_nodes(self, vals):

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,0 +1,10 @@
+## 19.0.0.3.13 (2026-06-30)
+
+- **Trunchiere referință comandă (BT-13) la 200 de caractere.** Pe facturile de
+  revânzare cu multe comenzi consolidate, câmpul „Referință client" (`ref`)
+  putea depăși 200 de caractere și ajungea ca atare în `cac:OrderReference/cbc:ID`
+  (BT-13), iar ANAF respingea transmiterea cu eroarea **BR-RO-L200** („Numărul
+  maxim permis de caractere pentru Referința comenzii (BT-13) este 200").
+  Acum BT-13 este limitat la 200 de caractere la generarea XML-ului, simetric
+  cu limitarea deja existentă pe `cbc:SalesOrderID` (BT-14), în
+  `_ubl_add_order_reference_node`.


### PR DESCRIPTION
Port of #442 (18.0) to 19.0.

## Context

Helpdesk ticket **#8913** (PTC ONLINE) — resale invoices could not be transmitted to SPV. ANAF rejected the upload with **BR-RO-L200** (max 200 chars for BT-13, purchase order reference).

## Root cause

Resale invoices consolidate many order references into the customer reference (`ref`) field, which Odoo maps into BT-13 (`cac:OrderReference/cbc:ID`) with no length limit. The module already truncated `cbc:SalesOrderID` (BT-14) but not `cbc:ID` (BT-13).

## Fix

Limit BT-13 to 200 chars in `_ubl_add_order_reference_node`, symmetric with the existing BT-14 truncation. Version bump + HISTORY entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)