### PR TITLE
[FIX] l10n_ro_efactura_enhancement: allow resending invoices rejected by ANAF

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "18.0.0.3.1",
+    "version": "18.0.0.3.2",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -387,7 +387,14 @@ class AccountMove(models.Model):
         already_sent = self.l10n_ro_edi_document_ids.filtered(
             lambda d: d.state in ("invoice_sent", "invoice_validated")
         )
-        if already_sent or self.l10n_ro_edi_index:
+        # l10n_ro_edi_index lingers on the invoice even after ANAF *rejects*
+        # the upload: the fetch/download flow switches the document to
+        # 'invoice_sending_failed' but never clears the index. A rejected
+        # upload is dead at ANAF, so a corrected invoice MUST be resendable.
+        # Treat the lingering index as a real duplicate risk only when there
+        # is no failing document overriding it.
+        rejected = self._l10n_ro_edi_get_failed_documents()
+        if already_sent or (self.l10n_ro_edi_index and not rejected):
             index = self.l10n_ro_edi_index or already_sent[:1].key_loading
             _logger.warning(
                 "E-Factura %s deja încărcată în SPV (index=%s); se evită re-trimiterea.",

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,15 @@
+## 18.0.0.3.2 (2026-06-30)
+
+- **Permite retrimiterea facturilor respinse de ANAF.** Garda de idempotență
+  bloca retrimiterea oricărei facturi care avea `l10n_ro_edi_index` setat. Însă
+  indexul rămâne pe factură și după ce ANAF *respinge* încărcarea (fluxul de
+  fetch/download din core trece documentul pe `invoice_sending_failed`, dar nu
+  șterge indexul). Astfel, o factură respinsă și apoi corectată nu mai putea fi
+  retrimisă. Acum indexul rămas este tratat ca risc de duplicat doar când NU
+  există un document `invoice_sending_failed` care să-l anuleze: o încărcare
+  respinsă este „moartă" la ANAF, deci factura corectată trebuie să fie
+  retrimisibilă. Modificat în `_l10n_ro_edi_send_invoice`.
+
 ## 18.0.0.3.1 (2026-06-30)
 
 - **Trunchiere referință comandă (BT-13) la 200 de caractere.** Pe facturile de

--- a/l10n_ro_efactura_enhancement/tests/test_spv_anti_duplicate.py
+++ b/l10n_ro_efactura_enhancement/tests/test_spv_anti_duplicate.py
@@ -92,6 +92,25 @@ class TestSpvAntiDuplicate(TransactionCase):
             invoice._l10n_ro_edi_send_invoice("<Invoice/>")
         mock_send.assert_not_called()
 
+    @mute_logger(LOGGER)
+    def test_resend_allowed_when_index_present_but_upload_rejected(self):
+        """Indexul rămâne pe factură și după respingerea la ANAF (documentul
+        trece pe 'invoice_sending_failed'). O factură respinsă și corectată
+        trebuie să poată fi retrimisă, nu blocată de indexul rămas."""
+        invoice = self._create_invoice()
+        invoice.l10n_ro_edi_index = "6520851057"
+        self.env["l10n_ro_edi.document"].create(
+            {
+                "invoice_id": invoice.id,
+                "state": "invoice_sending_failed",
+                "key_loading": "6520851057",
+                "datetime": fields.Datetime.now(),
+            }
+        )
+        with patch(SEND_METHOD, return_value={"key_loading": "9999999999"}) as mock_send:
+            invoice._l10n_ro_edi_send_invoice("<Invoice/>")
+        mock_send.assert_called_once()
+
     def test_clear_uncertain(self):
         """Butonul de resetare debifează marcajul incert."""
         invoice = self._create_invoice()


### PR DESCRIPTION
## Problema

Garda anti-duplicat din `_l10n_ro_edi_send_invoice` bloca retrimiterea oricărei facturi care avea `l10n_ro_edi_index` setat:

```python
if already_sent or self.l10n_ro_edi_index:
    ...  # skip send
```

Dar indexul **rămâne** pe factură și după ce ANAF *respinge* încărcarea. Fluxul de fetch/download din core (`l10n_ro_edi`) trece documentul pe `invoice_sending_failed`, dar **nu** șterge `l10n_ro_edi_index`. Rezultat: o factură respinsă și apoi corectată nu mai putea fi retrimisă — la "Send & Print" manual wizardul afișa eroarea veche și refuza retrimiterea.

## Soluția

Indexul rămas este tratat ca risc de duplicat **doar când nu există un document `invoice_sending_failed`** care să-l anuleze:

```python
rejected = self._l10n_ro_edi_get_failed_documents()
if already_sent or (self.l10n_ro_edi_index and not rejected):
    ...
```

- `already_sent` (`invoice_sent`/`invoice_validated`) → upload viu la ANAF → **blochează** (neschimbat).
- index setat + document eșuat → încărcare „moartă" la ANAF → **permite retrimiterea**.
- index setat fără document eșuat (ambiguu) → **blochează**, prudent.

Baza oricum resetează `l10n_ro_edi_index = False` la începutul retrimiterii, deci indexul mort e curățat.

Cazul timeout (`l10n_ro_edi_send_uncertain`) rămâne neschimbat — necesită în continuare verificare manuală în SPV.

## Teste

Adăugat `test_resend_allowed_when_index_present_but_upload_rejected` (index prezent + document `invoice_sending_failed` → trimiterea se execută). Testele existente rămân valide (index fără document eșuat = tot blocat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)