### PR TITLE
[19.0][FIX] l10n_ro_stock_picking_report: reception report group_id -> reference_ids on Odoo 19

### DIFF
--- a/l10n_ro_stock_picking_report/README.rst
+++ b/l10n_ro_stock_picking_report/README.rst
@@ -32,6 +32,22 @@ Romania - Terrabit - Picking Reports
 .. contents::
    :local:
 
+Changelog
+=========
+
+19.0.1.2.10
+-----------
+
+- **Fix:** reception report no longer crashes on Odoo 19.
+  ``stock.picking`` lost the ``group_id`` field (the procurement group
+  mechanism was replaced by ``stock.reference`` / ``reference_ids``),
+  which raised
+  ``AttributeError: 'stock.picking' object has no attribute 'group_id'``
+  when printing reception NIRs. The shared ``report_reception_text``
+  template now branches on field existence so it renders correctly for
+  both ``stock.picking`` (``reference_ids``) and the
+  ``stock.picking.cumulative`` report model (``group_id``).
+
 Bug Tracker
 ===========
 

--- a/l10n_ro_stock_picking_report/__manifest__.py
+++ b/l10n_ro_stock_picking_report/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Romania - Terrabit - Picking Reports",
     "summary": "Rapoarte: NIR, aviz, bon consum",
     "license": "AGPL-3",
-    "version": "19.0.1.2.9",
+    "version": "19.0.1.2.10",
     "development_status": "Mature",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",

--- a/l10n_ro_stock_picking_report/readme/HISTORY.md
+++ b/l10n_ro_stock_picking_report/readme/HISTORY.md
@@ -1,0 +1,9 @@
+## 19.0.1.2.10
+
+- **Fix:** reception report no longer crashes on Odoo 19. `stock.picking` lost
+  the `group_id` field (the procurement group mechanism was replaced by
+  `stock.reference` / `reference_ids`), which raised
+  `AttributeError: 'stock.picking' object has no attribute 'group_id'` when
+  printing reception NIRs. The shared `report_reception_text` template now
+  branches on field existence so it renders correctly for both `stock.picking`
+  (`reference_ids`) and the `stock.picking.cumulative` report model (`group_id`).

--- a/l10n_ro_stock_picking_report/static/description/index.html
+++ b/l10n_ro_stock_picking_report/static/description/index.html
@@ -381,32 +381,53 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-1">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-2">19.0.1.2.10</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="changelog">
+<h1><a class="toc-backref" href="#toc-entry-1">Changelog</a></h1>
+<div class="section" id="section-1">
+<h2><a class="toc-backref" href="#toc-entry-2">19.0.1.2.10</a></h2>
+<ul class="simple">
+<li><strong>Fix:</strong> reception report no longer crashes on Odoo 19.
+<tt class="docutils literal">stock.picking</tt> lost the <tt class="docutils literal">group_id</tt> field (the procurement group
+mechanism was replaced by <tt class="docutils literal">stock.reference</tt> / <tt class="docutils literal">reference_ids</tt>),
+which raised
+<tt class="docutils literal">AttributeError: 'stock.picking' object has no attribute 'group_id'</tt>
+when printing reception NIRs. The shared <tt class="docutils literal">report_reception_text</tt>
+template now branches on field existence so it renders correctly for
+both <tt class="docutils literal">stock.picking</tt> (<tt class="docutils literal">reference_ids</tt>) and the
+<tt class="docutils literal">stock.picking.cumulative</tt> report model (<tt class="docutils literal">group_id</tt>).</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.
 In case of trouble, please check there if your issue has already been reported.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Dorin Hongu</li>
 <li>Terrabit</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.nexterp.ro">NextERP Romania</a>:<ul>
 <li>Fekete Mihai &lt;<a class="reference external" href="mailto:feketemihai&#64;nexterp.ro">feketemihai&#64;nexterp.ro</a>&gt;</li>
@@ -422,7 +443,7 @@ In case of trouble, please check there if your issue has already been reported.<
 technical issues.</p>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/dhongu/l10n-romania/tree/19.0/l10n_ro_stock_picking_report">dhongu/l10n-romania</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/l10n_ro_stock_picking_report/views/report_picking.xml
+++ b/l10n_ro_stock_picking_report/views/report_picking.xml
@@ -879,12 +879,13 @@
     </template>
     <template id="report_reception_text">
         <div id="informations" class="row mt32 mb32">
-            <div class="col-3 bm-2" t-if="o.origin or o.group_id">
+            <div class="col-3 bm-2" t-if="o.origin or ('reference_ids' in o and o.reference_ids) or ('group_id' in o and o.group_id)">
                 <strong>Origin</strong>
                 <p>
                     <span t-esc="o.origin and o.origin[:30]" />
                     <t t-if="not  o.origin">
-                        <span t-field="o.group_id" />
+                        <span t-if="'reference_ids' in o" t-field="o.reference_ids" />
+                        <span t-elif="'group_id' in o" t-field="o.group_id" />
                     </t>
                 </p>
             </div>


### PR DESCRIPTION
## Context / de ce

Pe Odoo 19, tipărirea NIR-ului (raportul de recepție) din `l10n_ro_stock_picking_report`
eșua cu:

```
AttributeError: 'stock.picking' object has no attribute 'group_id'
Template: l10n_ro_stock_picking_report.report_reception_text
```

În Odoo 19 mecanismul `procurement.group` a fost eliminat, iar câmpul
`stock.picking.group_id` nu mai există — a fost înlocuit de noul model
`stock.reference` și de câmpul `reference_ids` (`Many2many` pe picking, related
prin `move_ids.reference_ids`). Template-ul de recepție folosea încă `o.group_id`.

## Ce s-a schimbat

- **`views/report_picking.xml`** — template-ul partajat `report_reception_text`:
  - `t-if`-ul și afișarea câmpului „Origin" nu mai folosesc `o.group_id` direct.
  - Template-ul este partajat între două modele: `stock.picking` (are
    `reference_ids`, nu mai are `group_id`) și `stock.picking.cumulative` (model
    de raport cumulativ care are propriul `group_id = fields.Char()`, fără
    `reference_ids`). De aceea afișarea ramifică pe existența câmpului
    (`'reference_ids' in o` / `'group_id' in o`), astfel încât ambele rapoarte
    randează corect.
- **`__manifest__.py`** — bump versiune `19.0.1.2.9` → `19.0.1.2.10`.
- **`readme/HISTORY.md`** (+ `README.rst`, `static/description/index.html`
  regenerate) — intrare de changelog pentru fix.

## Testare

Rulat pe DB curat, fără demo (`run_module_tests.sh` / `--without-demo=all`):

```
l10n_ro_stock_picking_report: 15 tests
0 failed, 0 error(s)
```

Suita acoperă rapoartele de recepție single-picking (`test_report_reception`,
`_no_tax`, `_sale_price`) și raportul cumulativ de recepție
(`test_report_cumulative_reception_sale_price`) — exact ramurile `stock.picking`
și `stock.picking.cumulative` ale template-ului partajat. Înainte de fix,
testul cumulativ pica cu `'stock.picking.cumulative' object has no attribute
'reference_ids'`; după fix, toate trec.

## Note / riscuri

- Fără migrări de date. Doar template + manifest + readme.
- Câmpul `reference_ids` fiind `Many2many`, când lipsește `origin` se afișează
  toate referințele de stoc legate de mișcări (echivalent funcțional cu vechea
  afișare a grupului de aprovizionare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)