### PR TITLE
[FIX/IMP] l10n_ro_efactura_enhancement: decouple email from SPV send + dedicated email cron (port 18.0)

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "19.0.0.3.14",
+    "version": "19.0.0.3.15",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "19.0.0.3.13",
+    "version": "19.0.0.3.14",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/data/ir_cron.xml
+++ b/l10n_ro_efactura_enhancement/data/ir_cron.xml
@@ -22,5 +22,17 @@
         <field name="interval_type">hours</field>
     </record>
 
+    <record id="ir_cron_l10n_ro_spv_send_validated_emails" model="ir.cron">
+        <field name="name">E-Factura: Trimite email facturi validate</field>
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="state">code</field>
+        <field
+            name="code"
+        >action = model._cron_l10n_ro_spv_send_validated_emails(limit=20, days=30, delay_days=0)</field>
+        <field name="user_id" ref="base.user_admin" />
+        <field name="interval_number">15</field>
+        <field name="interval_type">minutes</field>
+    </record>
+
 
 </odoo>

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -78,48 +78,10 @@ class AccountMove(models.Model):
             else:
                 _logger.info("No invoices to fetch status")
 
-            # Persist the SPV fetch results before the (decoupled) customer
-            # email step below. Emailing is isolated from the SPV read/write so
-            # a mail failure (SMTP error, serialization conflict during the
-            # send's flush, …) can never roll back the fetched statuses.
-            if not self.env.registry.in_test_mode():
-                self.env.cr.commit()  # pylint: disable=invalid-commit
-
-            # The customer invoice email is sent only AFTER the SPV validates the
-            # invoice, not at upload time. This way a rejected invoice that gets
-            # retried by the auto-send cron never emails the customer over and
-            # over. The l10n_ro_spv_validated_email_sent flag makes this
-            # idempotent and lets a failed email retry on a later run.
-            if not company.l10n_ro_spv_cron_no_email:
-                to_email = self.search(
-                    [
-                        ("move_type", "in", ("out_invoice", "out_refund")),
-                        ("state", "=", "posted"),
-                        ("date", "<", date_to),
-                        ("date", ">=", date_from),
-                        ("l10n_ro_edi_state", "=", "invoice_validated"),
-                        ("l10n_ro_spv_validated_email_sent", "=", False),
-                        ("company_id", "=", company.id),
-                    ],
-                    limit=limit,
-                )
-                if to_email:
-                    _logger.info(
-                        "📧 Sending customer email for SPV-validated invoices: %s",
-                        to_email.mapped("name"),
-                    )
-                    # Email is fully decoupled from the SPV flow: any failure is
-                    # logged and rolled back to the savepoint (so the
-                    # l10n_ro_spv_validated_email_sent flag isn't set and the
-                    # invoice is retried on a later run) without aborting the cron.
-                    try:
-                        with self.env.cr.savepoint():
-                            to_email._l10n_ro_spv_send_validated_email()
-                    except Exception:
-                        _logger.exception(
-                            "⚠️ Customer validated-email failed for %s; SPV statuses unaffected",
-                            company.name,
-                        )
+            # The customer invoice email is NOT sent here. It is fully decoupled
+            # into its own cron (_cron_l10n_ro_spv_send_validated_emails), so an
+            # email failure can never roll back the SPV statuses fetched above,
+            # and email delivery runs on its own schedule.
 
         if need_retrigger:
             at = fields.Datetime.now() + timedelta(minutes=2)
@@ -149,6 +111,53 @@ class AccountMove(models.Model):
             )
         # Flag every processed invoice (emailed or skipped) so it isn't requeried.
         self.l10n_ro_spv_validated_email_sent = True
+
+    def _cron_l10n_ro_spv_send_validated_emails(self, limit=20, days=30, delay_days=0):
+        """Send the customer invoice email for SPV-validated invoices, once.
+
+        Runs on its own schedule, fully independent of the SPV send/fetch crons.
+        The work is entirely query-driven and idempotent: it selects validated
+        invoices whose customer email hasn't been sent yet
+        (``l10n_ro_spv_validated_email_sent``), so it can safely retry on every
+        run. Kept out of the SPV read/write flow so an email failure can never
+        roll back SPV state. Each company is isolated in its own savepoint so a
+        failure for one company doesn't abort emails for the others (and leaves
+        the flag unset so those invoices retry next run).
+        """
+        _logger.info("⏱️ Cron job for sending validated-invoice emails")
+        domain = [("l10n_ro_edi_access_token", "!=", False)]
+        ro_companies = self or self.env["res.company"].sudo().search(domain)
+        for company in ro_companies:
+            if company.l10n_ro_spv_cron_no_email:
+                continue
+            date_to = fields.Date.today() - timedelta(days=delay_days)
+            date_from = fields.Date.today() - timedelta(days=days + delay_days)
+            to_email = self.search(
+                [
+                    ("move_type", "in", ("out_invoice", "out_refund")),
+                    ("state", "=", "posted"),
+                    ("date", "<", date_to),
+                    ("date", ">=", date_from),
+                    ("l10n_ro_edi_state", "=", "invoice_validated"),
+                    ("l10n_ro_spv_validated_email_sent", "=", False),
+                    ("company_id", "=", company.id),
+                ],
+                limit=limit,
+            )
+            if not to_email:
+                continue
+            _logger.info(
+                "📧 Sending customer email for SPV-validated invoices: %s",
+                to_email.mapped("name"),
+            )
+            try:
+                with self.env.cr.savepoint():
+                    to_email._l10n_ro_spv_send_validated_email()
+            except Exception:
+                _logger.exception(
+                    "⚠️ Customer validated-email failed for %s; will retry next run",
+                    company.name,
+                )
 
     def _cron_l10n_ro_edi_auto_send(self, limit=20, days=30, delay_days=0):
         """Trimiterea automata a facturilor din ziua precedenta in SPV"""

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -78,6 +78,13 @@ class AccountMove(models.Model):
             else:
                 _logger.info("No invoices to fetch status")
 
+            # Persist the SPV fetch results before the (decoupled) customer
+            # email step below. Emailing is isolated from the SPV read/write so
+            # a mail failure (SMTP error, serialization conflict during the
+            # send's flush, …) can never roll back the fetched statuses.
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()  # pylint: disable=invalid-commit
+
             # The customer invoice email is sent only AFTER the SPV validates the
             # invoice, not at upload time. This way a rejected invoice that gets
             # retried by the auto-send cron never emails the customer over and
@@ -101,7 +108,18 @@ class AccountMove(models.Model):
                         "📧 Sending customer email for SPV-validated invoices: %s",
                         to_email.mapped("name"),
                     )
-                    to_email._l10n_ro_spv_send_validated_email()
+                    # Email is fully decoupled from the SPV flow: any failure is
+                    # logged and rolled back to the savepoint (so the
+                    # l10n_ro_spv_validated_email_sent flag isn't set and the
+                    # invoice is retried on a later run) without aborting the cron.
+                    try:
+                        with self.env.cr.savepoint():
+                            to_email._l10n_ro_spv_send_validated_email()
+                    except Exception:
+                        _logger.exception(
+                            "⚠️ Customer validated-email failed for %s; SPV statuses unaffected",
+                            company.name,
+                        )
 
         if need_retrigger:
             at = fields.Datetime.now() + timedelta(minutes=2)
@@ -224,6 +242,14 @@ class AccountMove(models.Model):
                     **kwargs,
                 )
 
+            # Persist the SPV sends immediately, before the (decoupled) report
+            # email below. The report is a non-critical internal notification:
+            # a failure there (SMTP error, serialization conflict during the
+            # mail's flush/unlink, …) must never roll back the actual uploads
+            # or the cron retrigger.
+            if not self.env.registry.in_test_mode():
+                self.env.cr.commit()  # pylint: disable=invalid-commit
+
             # Recompute states after the send to build the run report.
             # NB: 'invoice_sent' only means the XML was uploaded to the SPV and is
             # awaiting validation — the SPV can still reject it later (async, via
@@ -234,18 +260,28 @@ class AccountMove(models.Model):
             validated = invoices.filtered(lambda inv: inv.l10n_ro_edi_state == "invoice_validated")
             pending = invoices.filtered(lambda inv: inv.l10n_ro_edi_state == "invoice_sent")
             failed_now = invoices - validated - pending
-            self._l10n_ro_spv_send_cron_report(
-                company,
-                {
-                    "candidates": candidates,
-                    "attempted": invoices,
-                    "validated": validated,
-                    "pending": pending,
-                    "failed_now": failed_now,
-                    "retrying": retrying,
-                    "exhausted": exhausted,
-                },
-            )
+            # Report email fully decoupled from the SPV send: isolated in a
+            # savepoint so any failure is logged instead of aborting the cron
+            # (the sends are already committed above).
+            try:
+                with self.env.cr.savepoint():
+                    self._l10n_ro_spv_send_cron_report(
+                        company,
+                        {
+                            "candidates": candidates,
+                            "attempted": invoices,
+                            "validated": validated,
+                            "pending": pending,
+                            "failed_now": failed_now,
+                            "retrying": retrying,
+                            "exhausted": exhausted,
+                        },
+                    )
+            except Exception:
+                _logger.exception(
+                    "⚠️ SPV cron report failed for %s; sends unaffected",
+                    company.name,
+                )
 
             if need_retrigger:
                 at = fields.Datetime.now() + timedelta(minutes=5)
@@ -314,20 +350,25 @@ class AccountMove(models.Model):
         if not template:
             _logger.warning("⚠️ SPV cron report template not found; skipping report for %s", company.name)
             return
+        # force_send=False: the report is queued as a mail.mail and delivered by
+        # the standard email queue cron, not sent synchronously here. This keeps
+        # SMTP delivery and the auto_delete unlink (whose flush was crashing the
+        # SPV send transaction on concurrent account_move updates) out of the
+        # SPV cron entirely — the email is fully separated from the SPV send.
         template.with_context(
             spv_rows=rows,
             spv_total=len(stats["attempted"]),
             spv_run=fields.Datetime.to_string(now),
         ).sudo().send_mail(
             company.id,
-            force_send=True,
+            force_send=False,
             email_values={
                 "email_to": recipients,
                 "email_from": company.email or company.partner_id.email or recipients,
                 "auto_delete": True,
             },
         )
-        _logger.info("📧 SPV cron report sent to %s for %s", recipients, company.name)
+        _logger.info("📧 SPV cron report queued to %s for %s", recipients, company.name)
 
     def action_send_to_spv_only(self):
         """Trimite facturile doar in SPV, fara email."""

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,25 @@
+## 19.0.0.3.14 (2026-07-01)
+
+- **Emailul este complet separat de trimiterea facturilor în SPV.** Cron-ul de
+  trimitere (`E-Factura: Send TO SPV`) rula fetch status → trimitere SPV →
+  email de raport → reprogramare într-o singură tranzacție. Când emailul de
+  raport eșua cu `SerializationFailure: could not serialize access due to
+  concurrent update` (conflict pe `account_move` cu importul din marketplace,
+  declanșat de `flush`-ul din `unlink`-ul mailului cu `auto_delete`), se făcea
+  rollback la **tot**: la trimiterile efective (facturile reapăreau ca „de
+  trimis") și la reprogramarea cron-ului (lanțul de auto-trimitere se rupea,
+  lăsând restul loturilor netrimise ore întregi).
+  - Trimiterile în SPV se **comit imediat** după `_generate_and_send_invoices`,
+    înainte de orice pas de email (fără commit în modul test).
+  - Emailul de raport este izolat în `savepoint` + `try/except` (eșecul se
+    loghează, nu oprește cron-ul) și trecut pe livrare prin coada de mail
+    (`force_send=False`), scoțând SMTP-ul și `unlink`-ul cu `auto_delete` din
+    tranzacția cron-ului.
+  - Emailul către client (după validare SPV, în cron-ul de fetch) este izolat
+    la fel: un eșec de email nu mai poate da rollback la statusurile citite din
+    SPV, iar factura se reia la rularea următoare (flag-ul
+    `l10n_ro_spv_validated_email_sent` rămâne nesetat).
+
 ## 19.0.0.3.13 (2026-06-30)
 
 - **Trunchiere referință comandă (BT-13) la 200 de caractere.** Pe facturile de

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,18 @@
+## 19.0.0.3.15 (2026-07-01)
+
+- **Emailul către client este acum un cron separat.** Trimiterea emailului
+  pentru facturile validate de SPV era executată în interiorul cron-ului de
+  fetch (`_cron_l10n_ro_edi_fetch_status`). Munca este însă complet condusă de
+  query și idempotentă (facturi `invoice_validated` cu
+  `l10n_ro_spv_validated_email_sent = False`), deci a fost mutată într-un cron
+  propriu, `E-Factura: Trimite email facturi validate`
+  (`_cron_l10n_ro_spv_send_validated_emails`, rulează la 15 minute).
+  - Emailul rulează independent de fluxul de citire/scriere SPV, pe orarul lui.
+  - Fiecare companie este izolată în propriul `savepoint`: un eșec la o companie
+    nu oprește emailurile pentru celelalte și lasă flag-ul nesetat, deci se reia
+    la rularea următoare.
+  - Necesită actualizarea modulului (`-u`) pentru a instala noul `ir.cron`.
+
 ## 19.0.0.3.14 (2026-07-01)
 
 - **Emailul este complet separat de trimiterea facturilor în SPV.** Cron-ul de


### PR DESCRIPTION
Port pe **19.0** al PR #446 (mergeat pe 18.0).

## Problemă

Analiza log-ului de producție (PTC Online) a arătat că **nu toate facturile ajungeau în SPV**. Cron-ul `E-Factura: Send TO SPV` rula într-o singură tranzacție: `fetch status → upload SPV → email de raport → reprogramare`. Când emailul de raport eșua cu `SerializationFailure: could not serialize access due to concurrent update` (conflict pe `account_move` cu importul din marketplace, declanșat de `flush`-ul din `unlink`-ul mailului cu `auto_delete`), se făcea **rollback la tot**: trimiterile efective (facturile reapăreau ca „de trimis") și reprogramarea cron-ului (lanțul de auto-trimitere se rupea, loturi netrimise ore întregi).

## Soluție

### 1. Separarea tranzacțională a emailului de trimiterea în SPV (`19.0.0.3.14`)
- **Commit** al încărcărilor în SPV imediat după `_generate_and_send_invoices`, înainte de orice email (sărit în modul test).
- **Emailul de raport** izolat în `savepoint` + `try/except` și trecut pe coada de mail (`force_send=False`) — SMTP-ul și `unlink`-ul cu `auto_delete` ies din tranzacția cron-ului.

### 2. Email către client → cron dedicat (`19.0.0.3.15`)
- nou `ir.cron` **`E-Factura: Trimite email facturi validate`** → `_cron_l10n_ro_spv_send_validated_emails`, la 15 minute;
- rulează independent de fluxul SPV; fiecare companie izolată în propriul `savepoint`;
- scos blocul de email din `_cron_l10n_ro_edi_fetch_status`.

## Note
- **Necesită `-u`** pe modul pentru a instala noul `ir.cron`.
- Cherry-pick `-x` din 18.0 (commit-urile ede1de70, 10852693); conflictele au fost doar pe versiune/HISTORY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)