### PR TITLE
[19.0][IMP] l10n_ro_stock_age_report: drop OCA dependencies

### DIFF
--- a/l10n_ro_stock_age_report/__manifest__.py
+++ b/l10n_ro_stock_age_report/__manifest__.py
@@ -4,12 +4,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Aged Report",
-    "version": "19.0.0.0.2",
+    "version": "19.0.0.0.3",
     "category": "Localization",
     "summary": "Romania - Stock Aged Report",
     "author": "Terrabit, NextERP Romania,Dakai Soft,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
-    "depends": ["l10n_ro_stock", "l10n_ro_stock_account"],
+    # doar stock_account (core) e necesar: property_stock_valuation_account_id pe
+    # categorie; câmpul OCA per-produs e citit defensiv cu hasattr în wizard
+    "depends": ["stock_account"],
     "development_status": "Production/Stable",
     "license": "AGPL-3",
     "data": [


### PR DESCRIPTION
## Ce face

Înlocuiește dependențele `l10n_ro_stock` + `l10n_ro_stock_account` (OCA) cu `stock_account` (core). Primul pas concret din planul de separare de OCA/l10n-romania.

## De ce e sigur

- **Zero referințe în cod** la `l10n_ro_stock` — dependență moștenită istoric (NextERP).
- Singurul punct de contact cu `l10n_ro_stock_account` este câmpul per-produs `l10n_ro_property_stock_valuation_account_id`, citit deja **defensiv cu `hasattr`** în `wizard/stock_age_report.py`, cu fallback pe `property_stock_valuation_account_id` de pe categorie (core `stock_account`).
- Numele modulului nu se schimbă → **zero scripturi de migrare** la upgrade 18→19.

## Verificare

- Instalare pe bază curată **fără OCA în addons_path**: OK (91 module încărcate).
- Teste: **2/2 passed** (`0 failed, 0 error(s)`).
- Cu stack-ul OCA instalat comportamentul rămâne identic (`hasattr` găsește câmpul per-produs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)