### PR TITLE
[IMP] l10n_ro_stock_picking_report: Aviz de însoțire a mărfii (14-3-6A)

### DIFF
--- a/l10n_ro_stock_picking_report/__manifest__.py
+++ b/l10n_ro_stock_picking_report/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Romania - Terrabit - Picking Reports",
     "summary": "Rapoarte: NIR, aviz, bon consum",
     "license": "AGPL-3",
-    "version": "19.0.1.2.11",
+    "version": "19.0.1.3.0",
     "development_status": "Mature",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",

--- a/l10n_ro_stock_picking_report/i18n/ro.po
+++ b/l10n_ro_stock_picking_report/i18n/ro.po
@@ -52,7 +52,12 @@ msgstr "<span>Delegat:</span>"
 #. module: l10n_ro_stock_picking_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_stock_picking_report.report_title
 msgid "<span>Delivery:</span>"
-msgstr "<span>Aviz:</span>"
+msgstr "<span>Livrare:</span>"
+
+#. module: l10n_ro_stock_picking_report
+#: model_terms:ir.ui.view,arch_db:l10n_ro_stock_picking_report.report_title
+msgid "<span>Goods Dispatch Note:</span>"
+msgstr "<span>Aviz de însoțire a mărfii:</span>"
 
 #. module: l10n_ro_stock_picking_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_stock_picking_report.report_delivery_sign

--- a/l10n_ro_stock_picking_report/readme/DESCRIPTION.md
+++ b/l10n_ro_stock_picking_report/readme/DESCRIPTION.md
@@ -2,3 +2,8 @@
 >   - Referinta din comanda de achizitie este copiata in NIR si factura
 >   - Option in settings (Romania) for printing taxes on reception
 >   - Option in settings (Romania) for printing banks on reports
+>   - Livrarile marcate ca aviz (`l10n_ro_notice`) se tiparesc cu titlul
+>     "Aviz de insotire a marfii" (14-3-6A); livrarile obisnuite raman "Livrare"
+>   - Pe livrarile fara comanda de vanzare (aviz, custodie, consignatie),
+>     raportul "Delivery with price" preia pretul din lista de preturi a
+>     partenerului sau pretul de lista al produsului

--- a/l10n_ro_stock_picking_report/report/picking.py
+++ b/l10n_ro_stock_picking_report/report/picking.py
@@ -54,6 +54,27 @@ class ReportPickingDelivery(models.AbstractModel):
             res["tax"] = taxes_sale["total_included"] - taxes_sale["total_excluded"]
             res["amount"] = taxes_sale["total_excluded"]
             res["amount_tax"] = taxes_sale["total_included"]
+        elif move_line.picking_id.picking_type_code == "outgoing" and move_line.product_id:
+            # livrare fara comanda de vanzare (ex. aviz de insotire, custodie, consignatie):
+            # pretul din lista de preturi a partenerului, altfel pretul de lista al produsului
+            product = move_line.product_id
+            partner = move_line.picking_id.partner_id
+            quantity = move_line.product_qty or move_line.product_uom_qty or 1.0
+
+            price = 0.0
+            pricelist = partner.property_product_pricelist if partner else False
+            if pricelist:
+                price = pricelist._get_product_price(product, quantity, uom=move_line.product_uom)
+            if not price:
+                price = product.list_price
+
+            taxes_ids = product.taxes_id.filtered(lambda tax: tax.company_id == move_line.company_id)
+            taxes_sale = taxes_ids.compute_all(price, quantity=quantity, product=product, partner=partner)
+
+            res["tax"] = taxes_sale["total_included"] - taxes_sale["total_excluded"]
+            res["amount"] = taxes_sale["total_excluded"]
+            res["amount_tax"] = taxes_sale["total_included"]
+            res["price"] = res["amount"] / quantity if quantity else price
 
         return res
 

--- a/l10n_ro_stock_picking_report/tests/test_stock_picking_report.py
+++ b/l10n_ro_stock_picking_report/tests/test_stock_picking_report.py
@@ -104,6 +104,29 @@ class TestL10nRoStockPickingReport(TransactionCase):
         self.assertIn("Price", html)
         self.assertIn("Amount", html)
 
+    def test_delivery_price_fallback_without_sale_order(self):
+        """Livrare fără comandă de vânzare (ex. aviz): prețul cade pe lista de prețuri / list_price."""
+        picking = self._create_picking(self.picking_type_out, qty=2.0, partner=self.partner_customer)
+        move = picking.move_ids[0]
+        self.assertFalse(move.sale_line_id)
+        handler = self.env["report.l10n_ro_stock_picking_report.report_delivery_price"]
+        res = handler._get_line(move)
+        self.assertAlmostEqual(res["price"], 20.0, places=2)
+        self.assertAlmostEqual(res["amount"], 40.0, places=2)
+        self.assertAlmostEqual(res["amount_tax"], res["amount"] + res["tax"], places=2)
+        totals = handler._get_totals(picking.move_ids)
+        self.assertAlmostEqual(totals["amount"], 40.0, places=2)
+
+    def test_report_delivery_notice_title(self):
+        """Livrarea marcată ca aviz se tipărește cu titlul de aviz de însoțire."""
+        if "l10n_ro_notice" not in self.env["stock.picking"]._fields:
+            self.skipTest("l10n_ro_stock_account is not installed (no l10n_ro_notice field)")
+        picking = self._create_picking(self.picking_type_out, qty=1.0, partner=self.partner_customer)
+        picking.l10n_ro_notice = True
+        html = self._render_report_html("l10n_ro_stock_picking_report.action_report_delivery_price", picking)
+        self.assertIn("Goods Dispatch Note:", html)
+        self.assertNotIn("Delivery:", html)
+
     def test_report_reception(self):
         picking = self._create_picking(self.picking_type_in, qty=3.0, partner=self.partner_supplier)
         html = self._render_report_html("l10n_ro_stock_picking_report.action_report_reception", picking)

--- a/l10n_ro_stock_picking_report/views/report_picking.xml
+++ b/l10n_ro_stock_picking_report/views/report_picking.xml
@@ -461,6 +461,11 @@
     </template>
 
     <template id="report_title">
+        <!-- livrare pe aviz: câmpul l10n_ro_notice există doar cu l10n_ro_stock_account instalat -->
+        <t
+            t-set="is_notice"
+            t-value="o.fields_get(['l10n_ro_notice']) and o.l10n_ro_notice"
+        />
         <h2>
 
 
@@ -469,7 +474,12 @@
                     <span>Reverse</span>
                 </t>
                 <t t-if="doc_type == 'delivery'">
-                    <span>Delivery:</span>
+                    <t t-if="is_notice">
+                        <span>Goods Dispatch Note:</span>
+                    </t>
+                    <t t-else="">
+                        <span>Delivery:</span>
+                    </t>
                 </t>
                 <t t-else="">
                     <span>Reception:</span>
@@ -484,6 +494,9 @@
                 <t t-if="doc_type == 'reception'">
                     <span>Reception:</span>
                 </t>
+                <t t-elif="is_notice">
+                    <span>Goods Dispatch Note:</span>
+                </t>
                 <t t-else="">
                     <span>Delivery:</span>
                 </t>
@@ -492,7 +505,12 @@
 
             <t t-if="o.picking_type_code == 'internal'">
                 <t t-if="doc_type == 'delivery'">
-                    <span>Delivery:</span>
+                    <t t-if="is_notice">
+                        <span>Goods Dispatch Note:</span>
+                    </t>
+                    <t t-else="">
+                        <span>Delivery:</span>
+                    </t>
                 </t>
                 <t t-else="">
                     <span t-field="o.picking_type_id.name" />


### PR DESCRIPTION
## Context

Din analiza exporturilor SAGA vs. rapoartele Odoo 19 (folderul `readme/comparatii/saga` din `l10n_ro_ent`), avizul de însoțire a mărfii era ~80% acoperit de raportul *Delivery with price*. Acest PR închide diferențele (etapa **E8** din plan).

## Ce face

- **Titlu de aviz**: livrările marcate ca aviz (`l10n_ro_notice`, câmp din `l10n_ro_stock_account`) se tipăresc „Aviz de însoțire a mărfii" (RO) / „Goods Dispatch Note" (EN), pe livrări, retururi și transferuri interne. Detectarea câmpului este defensivă (dependența de `l10n_ro_stock_account` rămâne opțională, ca în manifest).
- **Preț pe livrări fără comandă de vânzare**: pentru picking-uri `outgoing` fără `sale_line_id` (aviz, custodie, consignație, retur) prețul se ia din lista de prețuri a partenerului, altfel din prețul de listă al produsului. Înainte coloanele de preț ieșeau 0.
- **Corecție traducere**: „Delivery:" era tradus global „Aviz:". Acum livrarea obișnuită rămâne „Livrare:", iar „Aviz de însoțire a mărfii:" apare doar când `l10n_ro_notice` e bifat.

## Atenție (schimbare vizibilă)

Clienții care se bazau pe titlul „Aviz" tipărit la **orice** livrare vor vedea acum „Livrare:" pe livrările obișnuite. Titlul de aviz apare doar pe picking-urile cu `l10n_ro_notice`.

## Testare

15/15 teste trec pe o bază RO (`setup_country("ro")`), inclusiv 2 noi:
- fallback de preț pe livrare fără sale order (valori exacte);
- titlul de aviz la `l10n_ro_notice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)