### PR TITLE
[19.0][FIX] l10n_ro_efactura_enhancement: fara descriere duplicata in…

### DIFF
--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "19.0.0.3.15",
+    "version": "19.0.0.3.17",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_efactura_enhancement/models/account_edi_xml_cius_ro.py
@@ -28,26 +28,21 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
     def get_description(self, line):
         """
-        Returns only description
+        Returns only the additional description of the line, i.e. the line
+        name without the product name. Empty string when the line has no
+        description beyond the product itself — in that case the (optional)
+        cbc:Description tag must not be rendered at all.
         :param line: invoice line
         :return: description
         """
         line_name = line.name or ""
-        if line_name:
-            product = line.product_id
-            product_name = product.display_name or product.name or ""
-            if product and product_name and product_name in line_name:
-                if line_name != product_name:
-                    return line_name.replace(product_name, "", 1).strip()
-                else:
-                    return line_name
-            else:
-                return line_name
-        else:
-            if line.product_id:
-                return line.product_id.name or ""
-            else:
-                return line_name
+        if not line_name:
+            return ""
+        product = line.product_id
+        product_name = product.display_name or product.name or ""
+        if product and product_name and product_name in line_name:
+            return line_name.replace(product_name, "", 1).strip()
+        return line_name
 
     def _add_document_line_item_nodes(self, line_node, vals):
         # New helper extension: keep base behavior, then optionally use free-text line description
@@ -65,10 +60,12 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
             item["cbc:Name"] = {}
         desc = item["cbc:Description"]
         name = item["cbc:Name"]
-        # Default from product, truncated
+        # Default from product, truncated. Fără fallback pe product.name:
+        # numele produsului merge doar în cbc:Name; dacă nu există o descriere
+        # reală, tag-ul cbc:Description (opțional, BT-154) trebuie omis —
+        # serializatorul sare nodurile fără _text.
         if not desc.get("_text"):
-            default_desc = product.description_sale or product.name or ""
-            desc["_text"] = (default_desc or "")[:200]
+            desc["_text"] = (product.description_sale or "")[:200] or None
         else:
             desc["_text"] = desc["_text"][:200]
         if not name.get("_text"):
@@ -81,13 +78,16 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
         if use_line_desc:
             line = vals["base_line"]["record"]
-            if getattr(line, "name", None):
-                description = self.get_description(line)
-                if description:
-                    desc["_text"] = description[:200]
-                    name["_text"] = description[:100]
-        line_node["cac:Item"]["cbc:Description"]["_text"] = desc["_text"]
-        line_node["cac:Item"]["cbc:Name"]["_text"] = name["_text"]
+            # Descrierea suplimentară a liniei merge în cbc:Name; Description
+            # rămâne doar când textul depășește 100 de caractere (Name e
+            # trunchiat) — altfel ar dubla Name-ul și e omisă mai jos.
+            description = self.get_description(line) if getattr(line, "name", None) else ""
+            desc["_text"] = description[:200] if description else None
+            if description:
+                name["_text"] = description[:100]
+        # Descrierea nu trebuie să dubleze numele articolului.
+        if desc.get("_text") and desc["_text"] == name.get("_text"):
+            desc["_text"] = None
         if item.get("cac:AdditionalItemProperty"):
             item["cac:AdditionalItemProperty"] = []
         return res
@@ -114,16 +114,23 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         name = item["cbc:Name"]
         if use_line_desc:
             line = vals["base_line"]["record"]
-            # Normalize and truncate the line description
-            if getattr(line, "name", None):
-                description = self.get_description(line)
-                if description:
-                    desc["_text"] = description[:200]
-                    name["_text"] = description[:100]
+            # Core-ul a pus deja line.name (= display_name produs) în
+            # Description, deci suprascriem inclusiv cu None ca tag-ul să fie
+            # omis când linia nu are descriere proprie. Descrierea merge în
+            # cbc:Name; Description rămâne doar când textul depășește 100 de
+            # caractere (Name e trunchiat) — altfel ar dubla Name-ul și e
+            # omisă mai jos.
+            description = self.get_description(line) if getattr(line, "name", None) else ""
+            desc["_text"] = description[:200] if description else None
+            if description:
+                name["_text"] = description[:100]
 
         # When a free-text line description is used, drop additional properties
         if item.get("cac:AdditionalItemProperty"):
             item["cac:AdditionalItemProperty"] = []
+        # Descrierea nu trebuie să dubleze numele articolului.
+        if desc.get("_text") and desc["_text"] == name.get("_text"):
+            desc["_text"] = None
         # Truncare la limitele ANAF; dacă un nod a rămas gol îl punem înapoi pe
         # None ca serializatorul să sară peste tag-ul (opțional) gol.
         if desc.get("_text"):

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,30 @@
+## 19.0.0.3.17 (2026-07-03)
+
+- **Descrierea nu mai apare dublată în Description + Name.** Când linia avea o
+  descriere suplimentară, același text era pus atât în `cbc:Description` cât
+  și în `cbc:Name`, rezultând două tag-uri identice. Comportamentul rămâne cel
+  al parametrului (descrierea liniei merge în `cbc:Name`), dar tag-ul
+  `cbc:Description` se omite când ar fi identic cu `cbc:Name` — rămâne prezent
+  doar când descrierea depășește 100 de caractere, ca să poarte textul complet
+  (Name e trunchiat la 100, Description la 200). Doar cod Python, nu necesită
+  actualizarea modulului.
+
+## 19.0.0.3.16 (2026-07-03)
+
+- **Tag-ul `cbc:Description` este omis când linia nu are descriere proprie.**
+  Cu `efactura.use_line_description` activ, dacă numele liniei este identic cu
+  `display_name`-ul produsului (linie generată automat, fără text suplimentar),
+  în XML ajungea numele produsului (inclusiv codul `[COD]`) ca descriere.
+  `get_description` returnează acum doar descrierea suplimentară a liniei
+  (numele liniei fără numele produsului), iar când aceasta este goală nodul
+  `cbc:Description` (opțional, BT-154) este pus pe `None` și tag-ul nu mai
+  apare deloc în XML. `cbc:Name` rămâne numele produsului.
+  - Eliminat și fallback-ul pe `product.name` la descrierea implicită
+    (independent de parametru): numele produsului nu mai este duplicat în
+    Description — el există deja în `cbc:Name` și în
+    `cac:SellersItemIdentification`.
+  - Doar cod Python, nu necesită actualizarea modulului.
+
 ## 19.0.0.3.15 (2026-07-01)
 
 - **Emailul către client este acum un cron separat.** Trimiterea emailului

--- a/l10n_ro_efactura_enhancement/tests/test_account_move_enhancements.py
+++ b/l10n_ro_efactura_enhancement/tests/test_account_move_enhancements.py
@@ -249,10 +249,17 @@ class TestGetDescription(TransactionCase):
         self.assertEqual(result, "Serviciu consultanta")
 
     def test_get_description_name_equals_product(self):
-        """get_description returnează numele produsului când linia = produsul."""
+        """get_description returnează gol când linia = produsul (fără descriere proprie)."""
         line = self._make_line(self.product.display_name, product=self.product)
         result = self.model.get_description(line)
-        self.assertEqual(result, self.product.display_name)
+        self.assertEqual(result, "")
+
+    def test_get_description_name_equals_product_with_code(self):
+        """get_description returnează gol și când display_name include codul intern."""
+        product = self.env["product.product"].create({"name": "Produs Cod", "default_code": "COD123"})
+        line = self._make_line(product.display_name, product=product)
+        result = self.model.get_description(line)
+        self.assertEqual(result, "")
 
     def test_get_description_name_contains_product(self):
         """get_description elimină prefixul produsului din descrierea liniei."""
@@ -262,11 +269,11 @@ class TestGetDescription(TransactionCase):
         self.assertEqual(result, "- detalii suplimentare")
 
     def test_get_description_no_name_with_product(self):
-        """get_description returnează numele produsului când linia nu are nume."""
+        """get_description returnează gol când linia nu are nume (fără descriere în XML)."""
         line = self._make_line("x", product=self.product)
         line.name = False
         result = self.model.get_description(line)
-        self.assertEqual(result, self.product.name)
+        self.assertEqual(result, "")
 
     def test_get_description_no_name_no_product(self):
         """get_description returnează string gol când nu există nici nume nici produs."""


### PR DESCRIPTION
… XML e-Factura

Cu efactura.use_line_description activ:
- linia fara descriere proprie (nume = display_name produs) nu mai pune numele produsului in cbc:Description; tag-ul (optional, BT-154) este omis complet, cbc:Name ramane numele produsului
- descrierea liniei merge in cbc:Name; cbc:Description se omite cand ar fi identica cu Name si ramane doar cand textul depaseste 100 de caractere (Name trunchiat la 100, Description la 200)
- eliminat fallback-ul pe product.name la descrierea implicita din _add_document_line_item_nodes (numele produsului exista deja in cbc:Name si cac:SellersItemIdentification)

get_description returneaza acum doar descrierea suplimentara a liniei (numele liniei fara numele produsului), gol cand nu exista. Teste actualizate + caz nou cu default_code.