### PR TITLE
[19.0][ADD] l10n_ro_efactura_enhancement: opțiune per companie pentru oprirea importului automat de facturi din SPV

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ addon | version | maintainers | summary
 [l10n_ro_balance_confirmation](l10n_ro_balance_confirmation/) | 19.0.0.0.8 | <a href='https://github.com/danila12'><img src='https://github.com/danila12.png' width='32' height='32' style='border-radius:50%;' alt='danila12'/></a> | Generate balance confirmation for partners
 [l10n_ro_cash_register](l10n_ro_cash_register/) | 19.0.1.1.6 |  | Romania - Cash Register
 [l10n_ro_edi_ubl_sale_store](l10n_ro_edi_ubl_sale_store/) | 19.0.1.0.5 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | Sale from store
-[l10n_ro_efactura_enhancement](l10n_ro_efactura_enhancement/) | 19.0.0.0.11 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | eFactura Enhancement
+[l10n_ro_efactura_enhancement](l10n_ro_efactura_enhancement/) | 19.0.0.3.16 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | eFactura Enhancement
 [l10n_ro_etransport_enhancement](l10n_ro_etransport_enhancement/) | 19.0.0.1.1 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | eTransport enhancement
 [l10n_ro_footer_anpc](l10n_ro_footer_anpc/) | 19.0.0.0.1 | <a href='https://github.com/danila12'><img src='https://github.com/danila12.png' width='32' height='32' style='border-radius:50%;' alt='danila12'/></a> | Displays ANPC logos and links in website footer
 [l10n_ro_invoice_report](l10n_ro_invoice_report/) | 19.0.3.4.15 |  | Localizare Terrabit - Facturi, Chitanta

--- a/l10n_ro_efactura_enhancement/README.rst
+++ b/l10n_ro_efactura_enhancement/README.rst
@@ -10,9 +10,9 @@ eFactura Enhancement
    !! source digest: sha256:82dad9fd93fb19748471db3f4ba19840a80f821af9ff77805380aea4e6d1276b
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-.. |badge1| image:: https://img.shields.io/badge/maturity-Mature-brightgreen.png
+.. |badge1| image:: https://img.shields.io/badge/maturity-Production%2FStable-green.png
     :target: https://odoo-community.org/page/development-status
-    :alt: Mature
+    :alt: Production/Stable
 .. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
@@ -33,71 +33,281 @@ specific business needs for Romanian fiscal compliance.
 Key Features
 ------------
 
-- Automatic completion with 13 zeros for individual persons (physical
-  persons) in the VAT field
-- Ability to retransmit an invoice to the e-Factura system
-- Configurable system parameters:
+- **Automatic completion with 13 zeros** for individual persons
+  (physical persons) in the VAT field for e-invoice generation.
+- **Enhanced Address Validation**: Automatically checks that Romanian
+  partners have a country, state, city, and street defined before
+  posting an invoice.
+- **EDI Format Suggestion**: Automatically suggests the ``ciusro``
+  format for Romanian partners.
+- **Automated e-Invoice Operations**:
 
-  - 
+  - Cron job for **automatic sending** of posted invoices to SPV.
+  - Cron job for **fetching status** updates from SPV for sent invoices.
+  - **Server action "Trimite in SPV"**: Allows sending selected invoices
+    directly to SPV from the invoice list view, without triggering email
+    sending.
+  - **Configuration option**: A setting in the Accounting configuration
+    page controls whether the automatic SPV cron job suppresses email
+    sending (sends only to SPV).
+  - **Configuration option**: A per-company setting
+    (``Nu importa automat facturile primite din SPV``) lets you skip the
+    native "E-Factura: Synchronize with ANAF" auto-creation of received
+    vendor bills, while keeping the sent-invoice status synchronization
+    (accepted/refused) intact. Disabled by default, so native behavior
+    is unchanged unless explicitly enabled.
 
-    - Controls whether to include embedded PDF in the e-invoice
-      (Default: True) ``efactura.embed_pdf``
+- **Data Truncation and Sanitization**:
 
-  - 
+  - Truncates product names to 100 characters and descriptions to 200
+    characters to ensure compliance with UBL standards.
+  - Truncates notes to 300 characters.
+  - Truncates order references and despatch advice to 200 characters.
 
-    - Controls whether to clean the "/" character from invoice names in
-      the ID tag (Default: False) ``efactura.clean_name``
+- **POS Integration**: Automatically changes the document type code to
+  751 (Specialised Invoice) for invoices originating from Point of Sale.
+- **Configurable System Parameters**:
 
-  - 
+  - ``efactura.embed_pdf``: Controls whether to include the embedded PDF
+    in the e-invoice (Default: True).
+  - ``efactura.use_line_description``: If enabled, uses the invoice line
+    description instead of the product name/description in the e-invoice
+    (Default: False).
+  - ``efactura.replace_unit_uom``: Allows specifying a replacement unit
+    code for the standard 'C62' unit (Default: False).
+  - ``efactura.get_all_banks``: If enabled, includes all banks marked
+    with ``l10n_ro_print_report`` that match the invoice currency
+    (Default: False).
 
-    - Controls whether to include all banks with l10n_ro_print_report
-      and in the invoice currency (Default: False)
-      ``efactura.get_all_banks``
+- **Line Length Tracking**: Adds computed fields on invoice lines to
+  track the length of descriptions and product names, helping users
+  identify potential truncation issues.
 
 Technical Implementation
 ------------------------
 
-The module builds upon the standard Romanian localization and enhances
-the e-Factura integration with additional configuration options and data
-handling improvements.
+The module inherits and extends several base Odoo and Romanian
+localization models:
+
+- ``account.move``: Adds validation, cron jobs, and POS type handling.
+- ``account.edi.xml.ubl_ro``: Enhances UBL generation with custom logic
+  for addresses, product descriptions, and multi-bank support.
+- ``res.partner``: Overrides the EDI format suggestion for Romanian
+  entities.
+- ``account.move.line``: Adds UI helpers for label length.
 
 Business Benefits
 -----------------
 
-- Improved compliance with Romanian fiscal requirements
-- Enhanced flexibility in e-invoice generation and transmission
-- Better handling of special cases like individual customers without VAT
-  numbers
-- Support for retransmission of invoices when needed
+- **Improved Compliance**: Prevents errors by validating mandatory
+  address fields for Romanian fiscal reporting.
+- **Automation**: Reduces manual effort by automatically transmitting
+  and tracking e-invoices.
+- **Flexibility**: Provides granular control over how product
+  information and unit codes are mapped to the e-invoice.
+- **UBL Stability**: Ensures generated XML files remain within character
+  limit constraints for various fields.
 
 Usage
 -----
 
 After installation, the module automatically enhances the e-Factura
 functionality. System parameters can be configured in the technical
-settings to adjust behavior according to specific business needs. This
-module is part of the Romanian localization suite developed by Terrabit.
-
-Features:
-
-- Types can be defined for records sale.order, purchase.order,
-  account.move
-- If a model has no types defined, the type field will not be displayed
-- completare automata cu 13 de zero pt persane fizice
-- retransmiterea unei facturi
-- parametri sistem:
-
-  - "efactura.embed_pdf" - daca pune sau nu embedded pdf. Default pe
-    True
-  - "efactura.clean_name" - daca curata caracterul "/" din numele
-    facturii in tag-ul de ID. Default pe False
-  - "efactura.get_all_banks" - daca pune toate bancile cu
-    l10n_ro_print_report si in valuta facturii. Default pe False
+settings (``Settings > Technical > Parameters > System Parameters``) to
+adjust behavior according to specific business needs. This module is
+part of the Romanian localization suite developed by Terrabit.
 
 **Table of contents**
 
 .. contents::
    :local:
+
+Known issues / Roadmap
+======================
+
+Roadmap
+=======
+
+Known Bugs to Fix
+-----------------
+
+- **Missing system parameter defaults**: ``efactura.get_all_banks`` and
+  ``efactura.replace_unit_uom`` are used in the code but have no default
+  entries in ``data/ir_config_parameter.xml``. Add records with
+  ``False`` as default value.
+
+Fixed Bugs
+----------
+
+- ✅ **``_get_address_node`` tuple bug** *(v18.0.0.2.7)*: Line 41 in
+  ``models/account_edi_xml_cius_ro.py`` was assigning a tuple
+  ``({"_text": "Principala"},)`` instead of a dict
+  ``{"_text": "Principala"}``. Caused ``TypeError`` during XML
+  serialization for partners without a street address.
+
+- ✅ **``_ubl_add_accounting_supplier_party_legal_entity_nodes`` wrong
+  super call** *(v18.0.0.2.7)*: Was calling
+  ``super()._ubl_add_accounting_supplier_party_tax_scheme_nodes(vals)``
+  instead of
+  ``super()._ubl_add_accounting_supplier_party_legal_entity_nodes(vals)``.
+  When the supplier had no ``nrc``, the ``cac:PartyLegalEntity`` node
+  was omitted from the XML, producing an invalid e-invoice.
+
+- ✅ **Missing company filter in cron auto-send** *(v18.0.0.2.7)*: The
+  ``invoice_sending_failed`` domain in ``_cron_l10n_ro_edi_auto_send``
+  was not filtering by ``company_id``, causing invoices from all
+  companies to be collected instead of only the current company in the
+  loop.
+
+Planned Improvements
+--------------------
+
+Dashboard operațional eFactura (``l10n.ro.efactura.dashboard``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Obiectiv: pagină dedicată în meniul Accounting → Rapoarte → eFactura
+Dashboard care oferă o vedere rapidă a stării trimiterilor SPV cu
+navigare directă la liste filtrate.
+
+Funcționalități dorite:
+
+- **Stat buttons** pentru fiecare stare SPV:
+
+  - *De trimis* — facturi confirmate fără ``l10n_ro_edi_state`` (state
+    ``False``)
+  - *Trimise (în așteptare)* — ``invoice_sent``, trimise dar
+    neconfirmate încă de SPV
+  - *Neindexate* — ``invoice_not_indexed``, acceptate dar neindexate în
+    portalul ANAF
+  - *Validate* — ``invoice_validated``, acceptate și indexate cu succes
+  - *Refuzate* — ``invoice_refused``, respinse de SPV
+  - *Eroare trimitere* — ``invoice_sending_failed`` pe documentul EDI
+
+- **Click pe orice buton** deschide lista facturilor filtrate pe acea
+  stare
+- **Selector companie** pentru multi-company
+- **Acces**: grupurile ``account.group_account_invoice`` și
+  ``account.group_account_manager``
+
+Probleme tehnice identificate și rezolvate (de re-activat după testare):
+
+- View structurat cu ``oe_button_box`` ca prim copil al ``<sheet>``
+  (standard Odoo 19)
+- Server action returnează ``target: "current"`` în loc de ``"main"``
+  (compatibil TransientModel)
+- Atribute deprecate ``create/edit/delete`` eliminate din ``<form>``
+- Access rules adăugate în ``security/ir.model.access.csv``
+
+Codul modelului și view-ului este prezent dar **dezactivat temporar**
+(``efactura_dashboard.py``, ``views/efactura_dashboard_views.xml``) — de
+re-activat după validare pe o instanță live.
+
+Alte îmbunătățiri planificate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Re-enable wizard view**: Uncomment
+  ``wizard/account_move_send_views.xml`` in the manifest once the resend
+  UI flow is finalized for Odoo 18 (see TODO in
+  ``wizard/account_move_send.py``).
+
+- **UBL integration tests**: Add test cases covering XML generation for
+  invoices with and without street, with and without ``nrc``, and with
+  ``efactura.get_all_banks`` enabled, to prevent regressions in the UBL
+  override methods.
+
+- **Multi-company cron robustness**: Review both cron methods
+  (``_cron_l10n_ro_edi_auto_send`` and
+  ``_cron_l10n_ro_edi_fetch_status``) for correct company isolation
+  throughout all domain searches.
+
+- **English code comments**: Translate remaining Romanian inline
+  comments in ``models/account_move.py`` to English for consistency with
+  the project convention.
+
+- **``efactura.replace_unit_uom`` UI**: Expose the ``replace_unit_uom``
+  system parameter in the Accounting configuration page alongside the
+  existing ``l10n_ro_spv_cron_no_email`` setting.
+
+Changelog
+=========
+
+19.0.0.3.16 (2026-07-03)
+------------------------
+
+- **Opțiune de dezactivare a importului automat de facturi primite din
+  SPV.** Cron-ul nativ ``E-Factura: Synchronize with ANAF`` creează
+  automat ciorne de facturi de la furnizori din mesajele primite în SPV
+  (funcție nouă în Odoo 19, inexistentă pe 18). S-a adăugat un câmp per
+  companie ``l10n_ro_edi_no_auto_bill`` (Setări → Contabilitate →
+  secțiunea „eFactura SPV") care, când e activat, sare peste crearea
+  automată a acestor facturi.
+
+  - Implicit **dezactivat** (``False``): comportamentul nativ rămâne
+    neschimbat; activarea este o alegere explicită per companie.
+  - Este gardată **doar** metoda dedicată
+    ``_l10n_ro_edi_process_bill_messages``; procesarea răspunsurilor
+    pentru facturile trimise (acceptat/refuzat) și curățarea facturilor
+    neindexate din același cron rămân neatinse.
+
+19.0.0.3.15 (2026-07-01)
+------------------------
+
+- **Emailul către client este acum un cron separat.** Trimiterea
+  emailului pentru facturile validate de SPV era executată în interiorul
+  cron-ului de fetch (``_cron_l10n_ro_edi_fetch_status``). Munca este
+  însă complet condusă de query și idempotentă (facturi
+  ``invoice_validated`` cu
+  ``l10n_ro_spv_validated_email_sent = False``), deci a fost mutată
+  într-un cron propriu, ``E-Factura: Trimite email facturi validate``
+  (``_cron_l10n_ro_spv_send_validated_emails``, rulează la 15 minute).
+
+  - Emailul rulează independent de fluxul de citire/scriere SPV, pe
+    orarul lui.
+  - Fiecare companie este izolată în propriul ``savepoint``: un eșec la
+    o companie nu oprește emailurile pentru celelalte și lasă flag-ul
+    nesetat, deci se reia la rularea următoare.
+  - Necesită actualizarea modulului (``-u``) pentru a instala noul
+    ``ir.cron``.
+
+19.0.0.3.14 (2026-07-01)
+------------------------
+
+- **Emailul este complet separat de trimiterea facturilor în SPV.**
+  Cron-ul de trimitere (``E-Factura: Send TO SPV``) rula fetch status →
+  trimitere SPV → email de raport → reprogramare într-o singură
+  tranzacție. Când emailul de raport eșua cu
+  ``SerializationFailure: could not serialize access due to concurrent update``
+  (conflict pe ``account_move`` cu importul din marketplace, declanșat
+  de ``flush``-ul din ``unlink``-ul mailului cu ``auto_delete``), se
+  făcea rollback la **tot**: la trimiterile efective (facturile
+  reapăreau ca „de trimis") și la reprogramarea cron-ului (lanțul de
+  auto-trimitere se rupea, lăsând restul loturilor netrimise ore
+  întregi).
+
+  - Trimiterile în SPV se **comit imediat** după
+    ``_generate_and_send_invoices``, înainte de orice pas de email (fără
+    commit în modul test).
+  - Emailul de raport este izolat în ``savepoint`` + ``try/except``
+    (eșecul se loghează, nu oprește cron-ul) și trecut pe livrare prin
+    coada de mail (``force_send=False``), scoțând SMTP-ul și
+    ``unlink``-ul cu ``auto_delete`` din tranzacția cron-ului.
+  - Emailul către client (după validare SPV, în cron-ul de fetch) este
+    izolat la fel: un eșec de email nu mai poate da rollback la
+    statusurile citite din SPV, iar factura se reia la rularea următoare
+    (flag-ul ``l10n_ro_spv_validated_email_sent`` rămâne nesetat).
+
+19.0.0.3.13 (2026-06-30)
+------------------------
+
+- **Trunchiere referință comandă (BT-13) la 200 de caractere.** Pe
+  facturile de revânzare cu multe comenzi consolidate, câmpul „Referință
+  client" (``ref``) putea depăși 200 de caractere și ajungea ca atare în
+  ``cac:OrderReference/cbc:ID`` (BT-13), iar ANAF respingea transmiterea
+  cu eroarea **BR-RO-L200** („Numărul maxim permis de caractere pentru
+  Referința comenzii (BT-13) este 200"). Acum BT-13 este limitat la 200
+  de caractere la generarea XML-ului, simetric cu limitarea deja
+  existentă pe ``cbc:SalesOrderID`` (BT-14), în
+  ``_ubl_add_order_reference_node``.
 
 Bug Tracker
 ===========

--- a/l10n_ro_efactura_enhancement/__manifest__.py
+++ b/l10n_ro_efactura_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eFactura Enhancement",
-    "version": "19.0.0.3.15",
+    "version": "19.0.0.3.16",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "summary": "eFactura Enhancement",

--- a/l10n_ro_efactura_enhancement/models/account_move.py
+++ b/l10n_ro_efactura_enhancement/models/account_move.py
@@ -431,6 +431,29 @@ class AccountMove(models.Model):
 
         return super()._cron_account_move_send(job_count=job_count)
 
+    @api.model
+    def _l10n_ro_edi_process_bill_messages(self, received_bills_messages):
+        """Opreste importul automat al facturilor de furnizor din SPV, per companie.
+
+        Cronul nativ „E-Factura: Synchronize with ANAF" ruleaza intr-o singura
+        trecere trei operatii distincte (via ``_l10n_ro_edi_fetch_invoices``):
+        procesarea raspunsurilor pentru facturile TRIMISE (acceptat/refuzat),
+        curatarea facturilor neindexate si crearea ciornelor pentru facturile
+        PRIMITE. Suprascriem doar aceasta ultima metoda dedicata, astfel incat,
+        cand ``l10n_ro_edi_no_auto_bill`` e activ pe companie (implicit), se sare
+        peste crearea automata a facturilor de furnizor, iar restul functiilor
+        cronului raman neatinse.
+        """
+        if self.env.company.l10n_ro_edi_no_auto_bill:
+            _logger.info(
+                "⏭️ Import automat facturi furnizor din SPV dezactivat pentru %s; "
+                "%d mesaj(e) de facturi primite ignorate.",
+                self.env.company.name,
+                len(received_bills_messages),
+            )
+            return
+        return super()._l10n_ro_edi_process_bill_messages(received_bills_messages)
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"

--- a/l10n_ro_efactura_enhancement/models/res_config_settings.py
+++ b/l10n_ro_efactura_enhancement/models/res_config_settings.py
@@ -17,6 +17,14 @@ class ResCompany(models.Model):
         "fiecare rulare a cronului de trimitere in SPV. Daca e gol, raportul nu se "
         "trimite.",
     )
+    l10n_ro_edi_no_auto_bill = fields.Boolean(
+        string="Nu importa automat facturile primite din SPV",
+        default=False,
+        help='Cand este activat, cronul nativ „E-Factura: Synchronize with ANAF" nu '
+        "mai creeaza automat ciorne de facturi de la furnizori din mesajele primite in "
+        "SPV. Sincronizarea statusului facturilor trimise (acceptat/refuzat) ramane "
+        "activa.",
+    )
 
 
 class ResConfigSettings(models.TransientModel):
@@ -31,4 +39,9 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.l10n_ro_spv_cron_report_email",
         readonly=False,
         string="Email raport cron SPV",
+    )
+    l10n_ro_edi_no_auto_bill = fields.Boolean(
+        related="company_id.l10n_ro_edi_no_auto_bill",
+        readonly=False,
+        string="Nu importa automat facturile primite din SPV",
     )

--- a/l10n_ro_efactura_enhancement/readme/DESCRIPTION.md
+++ b/l10n_ro_efactura_enhancement/readme/DESCRIPTION.md
@@ -10,6 +10,7 @@ The l10n_ro_efactura_enhancement module extends the standard Romanian e-Invoicin
     - Cron job for **fetching status** updates from SPV for sent invoices.
     - **Server action "Trimite in SPV"**: Allows sending selected invoices directly to SPV from the invoice list view, without triggering email sending.
     - **Configuration option**: A setting in the Accounting configuration page controls whether the automatic SPV cron job suppresses email sending (sends only to SPV).
+    - **Configuration option**: A per-company setting (`Nu importa automat facturile primite din SPV`) lets you skip the native "E-Factura: Synchronize with ANAF" auto-creation of received vendor bills, while keeping the sent-invoice status synchronization (accepted/refused) intact. Disabled by default, so native behavior is unchanged unless explicitly enabled.
 - **Data Truncation and Sanitization**:
     - Truncates product names to 100 characters and descriptions to 200 characters to ensure compliance with UBL standards.
     - Truncates notes to 300 characters.

--- a/l10n_ro_efactura_enhancement/readme/HISTORY.md
+++ b/l10n_ro_efactura_enhancement/readme/HISTORY.md
@@ -1,3 +1,17 @@
+## 19.0.0.3.16 (2026-07-03)
+
+- **Opțiune de dezactivare a importului automat de facturi primite din SPV.**
+  Cron-ul nativ `E-Factura: Synchronize with ANAF` creează automat ciorne de
+  facturi de la furnizori din mesajele primite în SPV (funcție nouă în Odoo 19,
+  inexistentă pe 18). S-a adăugat un câmp per companie `l10n_ro_edi_no_auto_bill`
+  (Setări → Contabilitate → secțiunea „eFactura SPV") care, când e activat, sare
+  peste crearea automată a acestor facturi.
+  - Implicit **dezactivat** (`False`): comportamentul nativ rămâne neschimbat;
+    activarea este o alegere explicită per companie.
+  - Este gardată **doar** metoda dedicată `_l10n_ro_edi_process_bill_messages`;
+    procesarea răspunsurilor pentru facturile trimise (acceptat/refuzat) și
+    curățarea facturilor neindexate din același cron rămân neatinse.
+
 ## 19.0.0.3.15 (2026-07-01)
 
 - **Emailul către client este acum un cron separat.** Trimiterea emailului

--- a/l10n_ro_efactura_enhancement/tests/test_spv_actions.py
+++ b/l10n_ro_efactura_enhancement/tests/test_spv_actions.py
@@ -135,3 +135,38 @@ class TestSpvActions(TransactionCase):
         self.assertTrue(self.company.l10n_ro_spv_cron_no_email)
         self.company.l10n_ro_spv_cron_no_email = False
         self.assertFalse(self.company.l10n_ro_spv_cron_no_email)
+
+    def test_edi_no_auto_bill_default_false(self):
+        """Implicit, auto-importul facturilor primite din SPV rămâne activ (default False)."""
+        defaults = self.env["res.company"].default_get(["l10n_ro_edi_no_auto_bill"])
+        self.assertFalse(defaults.get("l10n_ro_edi_no_auto_bill"))
+
+    def test_edi_no_auto_bill_config(self):
+        """Test că setarea l10n_ro_edi_no_auto_bill se salvează corect pe companie."""
+        self.company.l10n_ro_edi_no_auto_bill = True
+        self.assertTrue(self.company.l10n_ro_edi_no_auto_bill)
+        self.company.l10n_ro_edi_no_auto_bill = False
+        self.assertFalse(self.company.l10n_ro_edi_no_auto_bill)
+
+    def test_no_auto_bill_true_skips_native_import(self):
+        """Cu flagul activ, override-ul nu mai apelează logica nativă de creare a
+        facturilor primite (restul cron-ului „Synchronize with ANAF" rămâne neatins)."""
+        from odoo.addons.l10n_ro_edi.models.account_move import (
+            AccountMove as NativeAccountMove,
+        )
+
+        self.company.l10n_ro_edi_no_auto_bill = True
+        with patch.object(NativeAccountMove, "_l10n_ro_edi_process_bill_messages") as native:
+            self.env["account.move"].with_company(self.company)._l10n_ro_edi_process_bill_messages([{"id": "1"}])
+            native.assert_not_called()
+
+    def test_no_auto_bill_false_delegates_to_native(self):
+        """Fără flag (implicit), override-ul deleagă către logica nativă de import."""
+        from odoo.addons.l10n_ro_edi.models.account_move import (
+            AccountMove as NativeAccountMove,
+        )
+
+        self.company.l10n_ro_edi_no_auto_bill = False
+        with patch.object(NativeAccountMove, "_l10n_ro_edi_process_bill_messages", return_value=None) as native:
+            self.env["account.move"].with_company(self.company)._l10n_ro_edi_process_bill_messages([{"id": "1"}])
+            native.assert_called_once()

--- a/l10n_ro_efactura_enhancement/views/res_config_settings_views.xml
+++ b/l10n_ro_efactura_enhancement/views/res_config_settings_views.xml
@@ -26,6 +26,14 @@
                             placeholder="contabilitate@firma.ro, manager@firma.ro"
                         />
                     </setting>
+                    <setting
+                        title="Când este activat, cron-ul nativ „E-Factura: Synchronize with ANAF” nu mai creează automat ciorne de facturi de la furnizori din SPV. Sincronizarea statusului facturilor trimise (acceptat/refuzat) rămâne activă."
+                        id="l10n_ro_edi_no_auto_bill"
+                        string="Nu importa automat facturile primite din SPV"
+                        help="Bifați dacă nu doriți ca facturile primite în SPV să fie create automat ca ciorne. Restul sincronizării cu ANAF rămâne neschimbat."
+                    >
+                        <field name="l10n_ro_edi_no_auto_bill" />
+                    </setting>
                 </block>
             </xpath>
         </field>


### PR DESCRIPTION
## Context / de ce

În Odoo 19, modulul nativ `l10n_ro_edi` a căpătat o funcție nouă (inexistentă pe 18):
cronul **„E-Factura: Synchronize with ANAF"** (`_cron_l10n_ro_edi_synchronize_invoices`
→ `_l10n_ro_edi_fetch_invoices` → `_l10n_ro_edi_process_bill_messages`) **creează automat
ciorne de facturi de la furnizori** din mesajele primite în SPV.

Unii clienți nu doresc acest comportament (preferă înregistrarea manuală a facturilor
primite, ca înainte de migrarea pe 19). Nu există în nativ un buton de dezactivare granular:
cronul face într-o singură trecere și sincronizarea statusului facturilor **trimise**
(acceptat/refuzat) și curățarea facturilor neindexate, deci simpla dezactivare a cronului ar
opri și aceste funcții utile.

## Ce s-a schimbat

- **`res.company` / `res.config.settings`** (`models/res_config_settings.py`): câmp nou
  `l10n_ro_edi_no_auto_bill` (Boolean, **default `False`**) + related pe settings.
- **`account.move`** (`models/account_move.py`): override `@api.model
  _l10n_ro_edi_process_bill_messages` — când flagul e activ pe companie, sare peste crearea
  automată a facturilor primite și returnează devreme; altfel deleagă la `super()`.
  Este gardată **doar** această metodă dedicată, deci restul cronului rămâne intact.
- **Setări** (`views/res_config_settings_views.xml`): toggle în secțiunea „eFactura SPV"
  din Setări → Contabilitate.
- **Documentație** (`readme/DESCRIPTION.md`, `readme/HISTORY.md`) + bump manifest la
  `19.0.0.3.16`.

## Comportament

- **Default `False`**: comportamentul nativ rămâne neschimbat (auto-import activ). Activarea
  este o alegere explicită, per companie.
- Cu flagul activ: NU se mai creează automat facturi de furnizor din SPV; procesarea
  răspunsurilor pentru facturile trimise (acceptat/refuzat) și curățarea facturilor
  neindexate din același cron **rămân neatinse**.

## Testare

Adăugate 4 teste în `tests/test_spv_actions.py`:
- `test_edi_no_auto_bill_default_false` — default-ul câmpului este `False`.
- `test_edi_no_auto_bill_config` — setarea se salvează corect pe companie.
- `test_no_auto_bill_true_skips_native_import` — cu flag activ, logica nativă NU este apelată.
- `test_no_auto_bill_false_delegates_to_native` — fără flag, override-ul deleagă la `super()`.

Rulat pe Odoo 19 (`-u l10n_ro_efactura_enhancement --test-enable --test-tags
/l10n_ro_efactura_enhancement`): **0 failed, 0 error(s) of 31 tests**.

## Versiuni

Doar **19.0**. Funcția nativă de auto-import a facturilor primite **nu există pe Odoo 18**
(`l10n_ro_edi` 18 are doar refresh token + fetch status pe facturile trimise), deci nu este
necesar port pe 18.

## Note / riscuri

- Fără migrare de date. Câmpul nou este un Boolean nullable cu default `False`; la update-ul
  modulului toate companiile existente păstrează comportamentul nativ.
- README.rst este generat de hook-ul `oca-gen-addon-readme` din fragmentele `readme/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)