### PR TITLE
[FIX] l10n_ro_etransport_enhancement: cantitate=0 lines dropped before ANAF submit

### DIFF
--- a/l10n_ro_etransport_enhancement/README.rst
+++ b/l10n_ro_etransport_enhancement/README.rst
@@ -82,6 +82,27 @@ localizare pentru România dezvoltată de Terrabit.
 .. contents::
    :local:
 
+Changelog
+=========
+
+18.0.0.2.3 (2026-07-08)
+-----------------------
+
+- **Fixed ANAF rejection: "Attribute 'cantitate' must appear on element
+  'bunuriTransportate'".** The zero-quantity cleanup in
+  ``_l10n_ro_edi_stock_get_template_data`` only ran when the *last*
+  stock move iterated in the preceding loop belonged to a company with
+  ``l10n_ro_etransport_get_validated_qty`` enabled. When that setting
+  was off, or when the order-value loop never ran
+  (``l10n_ro_etransport_get_order_value`` disabled), a
+  ``bunuriTransportate`` line with ``cantitate == 0`` was never removed.
+  The QWeb template renders ``cantitate`` via ``t-att-cantitate``, and
+  Odoo's QWeb compiler silently drops any ``t-att-*`` attribute whose
+  value is falsy (``0``/``0.0``) and not already a string — so the
+  attribute vanished from the generated XML and ANAF's XSD validation
+  rejected the document. The cleanup now runs unconditionally in
+  ``_l10n_ro_edi_stock_get_template_data``.
+
 Bug Tracker
 ===========
 

--- a/l10n_ro_etransport_enhancement/__manifest__.py
+++ b/l10n_ro_etransport_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eTransport Enhancement",
-    "version": "18.0.0.2.2",
+    "version": "18.0.0.2.3",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eTransport enhancement",

--- a/l10n_ro_etransport_enhancement/models/stock_picking.py
+++ b/l10n_ro_etransport_enhancement/models/stock_picking.py
@@ -190,12 +190,11 @@ class Picking(models.Model):
                                 item["greutateBruta"] = round(weight_line.gross_weight, 2)
                     item_no += 1
         # remove lines with 0 quantity, it's possible when the validated qty is used
-        if move_id and move_id.company_id.l10n_ro_etransport_get_validated_qty:
-            for item in res["data"]["notificare"]["bunuriTransportate"]:
-                if float_is_zero(item["cantitate"], precision_rounding=0.01):
-                    res["data"]["notificare"]["bunuriTransportate"].pop(
-                        res["data"]["notificare"]["bunuriTransportate"].index(item)
-                    )
+        # (must run unconditionally: the XSD requires 'cantitate' on every bunuriTransportate
+        # element, and a 0 quantity is dropped silently by the QWeb template rendering)
+        for item in res["data"]["notificare"]["bunuriTransportate"][:]:
+            if float_is_zero(item["cantitate"], precision_rounding=0.01):
+                res["data"]["notificare"]["bunuriTransportate"].remove(item)
         return res
 
     def action_l10n_ro_edi_stock_fetch_status(self):

--- a/l10n_ro_etransport_enhancement/readme/HISTORY.md
+++ b/l10n_ro_etransport_enhancement/readme/HISTORY.md
@@ -1,0 +1,14 @@
+## 18.0.0.2.3 (2026-07-08)
+
+- **Fixed ANAF rejection: "Attribute 'cantitate' must appear on element
+  'bunuriTransportate'".** The zero-quantity cleanup in
+  `_l10n_ro_edi_stock_get_template_data` only ran when the *last* stock move
+  iterated in the preceding loop belonged to a company with
+  `l10n_ro_etransport_get_validated_qty` enabled. When that setting was off, or
+  when the order-value loop never ran (`l10n_ro_etransport_get_order_value`
+  disabled), a `bunuriTransportate` line with `cantitate == 0` was never
+  removed. The QWeb template renders `cantitate` via `t-att-cantitate`, and
+  Odoo's QWeb compiler silently drops any `t-att-*` attribute whose value is
+  falsy (`0`/`0.0`) and not already a string — so the attribute vanished from
+  the generated XML and ANAF's XSD validation rejected the document. The
+  cleanup now runs unconditionally in `_l10n_ro_edi_stock_get_template_data`.

--- a/l10n_ro_etransport_enhancement/static/description/index.html
+++ b/l10n_ro_etransport_enhancement/static/description/index.html
@@ -427,18 +427,39 @@ localizare pentru România dezvoltată de Terrabit.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-1">Changelog</a></li>
 </ul>
 </div>
+<div class="section" id="changelog">
+<h2><a class="toc-backref" href="#toc-entry-1">Changelog</a></h2>
+</div>
+</div>
+<div class="section" id="section-1">
+<h1>18.0.0.2.3 (2026-07-08)</h1>
+<ul class="simple">
+<li><strong>Fixed ANAF rejection: “Attribute ‘cantitate’ must appear on element
+‘bunuriTransportate’”.</strong> The zero-quantity cleanup in
+<tt class="docutils literal">_l10n_ro_edi_stock_get_template_data</tt> only ran when the <em>last</em>
+stock move iterated in the preceding loop belonged to a company with
+<tt class="docutils literal">l10n_ro_etransport_get_validated_qty</tt> enabled. When that setting
+was off, or when the order-value loop never ran
+(<tt class="docutils literal">l10n_ro_etransport_get_order_value</tt> disabled), a
+<tt class="docutils literal">bunuriTransportate</tt> line with <tt class="docutils literal">cantitate == 0</tt> was never removed.
+The QWeb template renders <tt class="docutils literal">cantitate</tt> via <tt class="docutils literal"><span class="pre">t-att-cantitate</span></tt>, and
+Odoo’s QWeb compiler silently drops any <tt class="docutils literal"><span class="pre">t-att-*</span></tt> attribute whose
+value is falsy (<tt class="docutils literal">0</tt>/<tt class="docutils literal">0.0</tt>) and not already a string — so the
+attribute vanished from the generated XML and ANAF’s XSD validation
+rejected the document. The cleanup now runs unconditionally in
+<tt class="docutils literal">_l10n_ro_edi_stock_get_template_data</tt>.</li>
+</ul>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2>Bug Tracker</h2>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.
 In case of trouble, please check there if your issue has already been reported.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2>Credits</h2>
 </div>
 </div>
 <div class="section" id="authors">


### PR DESCRIPTION
## Summary
- ANAF rejects eTransport submissions with `Attribute 'cantitate' must appear on element 'bunuriTransportate'` when a `bunuriTransportate` line ends up with quantity 0.
- The zero-quantity cleanup in `_l10n_ro_edi_stock_get_template_data` only ran when the *last* stock move iterated in the preceding loop belonged to a company with `l10n_ro_etransport_get_validated_qty` enabled — if that setting was off, or the order-value loop never ran, a `cantitate == 0` line was left in the payload.
- QWeb's `t-att-*` silently drops any attribute whose value is falsy and not already a string, so `cantitate="0"` vanished entirely from the generated XML, and ANAF's XSD validation then rejected the whole document.
- The cleanup now runs unconditionally, regardless of the validated-qty setting or which branch executed.

## Test plan
- [ ] Generate an eTransport document for a picking with a move whose validated quantity is 0 and confirm the resulting `bunuriTransportate` list no longer contains that line.
- [ ] Generate an eTransport document for a normal picking (no zero-quantity moves) and confirm output is unchanged.
- [ ] Submit to ANAF sandbox/test environment and confirm no more `cantitate` XSD rejection.