### PR TITLE
[FIX] l10n_ro_etransport(_batch)_enhancement: missing label on Custom Shipping Weights

### DIFF
--- a/l10n_ro_etransport_batch_enhancement/README.rst
+++ b/l10n_ro_etransport_batch_enhancement/README.rst
@@ -60,6 +60,21 @@ Implementare Tehnică
 .. contents::
    :local:
 
+Changelog
+=========
+
+18.0.0.1.2 (2026-07-08)
+-----------------------
+
+- **Fixed missing label on "Custom Shipping Weights" checkbox.** Same
+  nested-group issue as ``l10n_ro_etransport_enhancement``: the
+  ``weights`` group on the batch form's eTransport tab nested a plain
+  ``<group>`` (holding ``total_net_weight``/``total_gross_weight``),
+  which flips the whole outer group into Odoo's "OuterGroup" rendering
+  and silently drops automatic labels for every plain field in it. The
+  nested group was removed so ``weights`` renders as a normal InnerGroup
+  with labels.
+
 Bug Tracker
 ===========
 

--- a/l10n_ro_etransport_batch_enhancement/__manifest__.py
+++ b/l10n_ro_etransport_batch_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eTransport Batch Enhancement",
-    "version": "18.0.0.1.1",
+    "version": "18.0.0.1.2",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eTransport Batch Enhancement",

--- a/l10n_ro_etransport_batch_enhancement/readme/HISTORY.md
+++ b/l10n_ro_etransport_batch_enhancement/readme/HISTORY.md
@@ -1,0 +1,9 @@
+## 18.0.0.1.2 (2026-07-08)
+
+- **Fixed missing label on "Custom Shipping Weights" checkbox.** Same
+  nested-group issue as `l10n_ro_etransport_enhancement`: the `weights` group
+  on the batch form's eTransport tab nested a plain `<group>` (holding
+  `total_net_weight`/`total_gross_weight`), which flips the whole outer group
+  into Odoo's "OuterGroup" rendering and silently drops automatic labels for
+  every plain field in it. The nested group was removed so `weights` renders
+  as a normal InnerGroup with labels.

--- a/l10n_ro_etransport_batch_enhancement/static/description/index.html
+++ b/l10n_ro_etransport_batch_enhancement/static/description/index.html
@@ -406,18 +406,33 @@ transport manual de pe lot.</li>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-1">Changelog</a></li>
 </ul>
 </div>
+<div class="section" id="changelog">
+<h2><a class="toc-backref" href="#toc-entry-1">Changelog</a></h2>
+</div>
+</div>
+<div class="section" id="section-1">
+<h1>18.0.0.1.2 (2026-07-08)</h1>
+<ul class="simple">
+<li><strong>Fixed missing label on “Custom Shipping Weights” checkbox.</strong> Same
+nested-group issue as <tt class="docutils literal">l10n_ro_etransport_enhancement</tt>: the
+<tt class="docutils literal">weights</tt> group on the batch form’s eTransport tab nested a plain
+<tt class="docutils literal">&lt;group&gt;</tt> (holding <tt class="docutils literal">total_net_weight</tt>/<tt class="docutils literal">total_gross_weight</tt>),
+which flips the whole outer group into Odoo’s “OuterGroup” rendering
+and silently drops automatic labels for every plain field in it. The
+nested group was removed so <tt class="docutils literal">weights</tt> renders as a normal InnerGroup
+with labels.</li>
+</ul>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2>Bug Tracker</h2>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.
 In case of trouble, please check there if your issue has already been reported.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2>Credits</h2>
 </div>
 </div>
 <div class="section" id="authors">

--- a/l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml
+++ b/l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml
@@ -13,10 +13,8 @@
             <page name="etransport" position="inside">
                 <group name="weights">
                     <field name="l10n_ro_shipping_weights" />
-                    <group>
-                        <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
-                        <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
-                    </group>
+                    <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
+                    <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
                     <field
                         name="l10n_ro_shipping_weight_lines"
                         invisible="not l10n_ro_shipping_weights"

--- a/l10n_ro_etransport_enhancement/README.rst
+++ b/l10n_ro_etransport_enhancement/README.rst
@@ -85,6 +85,20 @@ localizare pentru România dezvoltată de Terrabit.
 Changelog
 =========
 
+18.0.0.2.5 (2026-07-08)
+-----------------------
+
+- **Fixed missing label on "Custom Shipping Weights" checkbox.** The
+  ``weights`` group on the picking form's eTransport tab nested a plain
+  ``<group>`` (holding ``total_net_weight``/``total_gross_weight``)
+  inside itself. Odoo's form compiler renders a ``<group>`` as an
+  "OuterGroup" (a group of groups) whenever any direct child is itself a
+  ``<group>``, and OuterGroup mode skips automatic label generation for
+  every plain field in it — so ``l10n_ro_shipping_weights`` showed up
+  with no caption. The nested group was removed;
+  ``total_net_weight``/``total_gross_weight`` are now direct fields of
+  ``weights``, which renders as a normal InnerGroup with labels.
+
 18.0.0.2.4 (2026-07-08)
 -----------------------
 

--- a/l10n_ro_etransport_enhancement/__manifest__.py
+++ b/l10n_ro_etransport_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eTransport Enhancement",
-    "version": "18.0.0.2.4",
+    "version": "18.0.0.2.5",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eTransport enhancement",

--- a/l10n_ro_etransport_enhancement/readme/HISTORY.md
+++ b/l10n_ro_etransport_enhancement/readme/HISTORY.md
@@ -1,3 +1,15 @@
+## 18.0.0.2.5 (2026-07-08)
+
+- **Fixed missing label on "Custom Shipping Weights" checkbox.** The
+  `weights` group on the picking form's eTransport tab nested a plain
+  `<group>` (holding `total_net_weight`/`total_gross_weight`) inside itself.
+  Odoo's form compiler renders a `<group>` as an "OuterGroup" (a group of
+  groups) whenever any direct child is itself a `<group>`, and OuterGroup mode
+  skips automatic label generation for every plain field in it — so
+  `l10n_ro_shipping_weights` showed up with no caption. The nested group was
+  removed; `total_net_weight`/`total_gross_weight` are now direct fields of
+  `weights`, which renders as a normal InnerGroup with labels.
+
 ## 18.0.0.2.4 (2026-07-08)
 
 - **Fixed ANAF rejection: "Attribute 'greutateBruta' must appear on element

--- a/l10n_ro_etransport_enhancement/static/description/index.html
+++ b/l10n_ro_etransport_enhancement/static/description/index.html
@@ -435,6 +435,21 @@ localizare pentru România dezvoltată de Terrabit.</p>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>18.0.0.2.5 (2026-07-08)</h1>
+<ul class="simple">
+<li><strong>Fixed missing label on “Custom Shipping Weights” checkbox.</strong> The
+<tt class="docutils literal">weights</tt> group on the picking form’s eTransport tab nested a plain
+<tt class="docutils literal">&lt;group&gt;</tt> (holding <tt class="docutils literal">total_net_weight</tt>/<tt class="docutils literal">total_gross_weight</tt>)
+inside itself. Odoo’s form compiler renders a <tt class="docutils literal">&lt;group&gt;</tt> as an
+“OuterGroup” (a group of groups) whenever any direct child is itself a
+<tt class="docutils literal">&lt;group&gt;</tt>, and OuterGroup mode skips automatic label generation for
+every plain field in it — so <tt class="docutils literal">l10n_ro_shipping_weights</tt> showed up
+with no caption. The nested group was removed;
+<tt class="docutils literal">total_net_weight</tt>/<tt class="docutils literal">total_gross_weight</tt> are now direct fields of
+<tt class="docutils literal">weights</tt>, which renders as a normal InnerGroup with labels.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>18.0.0.2.4 (2026-07-08)</h1>
 <ul class="simple">
 <li><strong>Fixed ANAF rejection: “Attribute ‘greutateBruta’ must appear on
@@ -451,7 +466,7 @@ versa) as an approximation, so a missing product weight no longer
 breaks the whole submission.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h1>18.0.0.2.3 (2026-07-08)</h1>
 <ul class="simple">
 <li><strong>Fixed ANAF rejection: “Attribute ‘cantitate’ must appear on element

--- a/l10n_ro_etransport_enhancement/views/stock_picking_view.xml
+++ b/l10n_ro_etransport_enhancement/views/stock_picking_view.xml
@@ -12,10 +12,8 @@
             <page name="etransport" position="inside">
                 <group name="weights">
                     <field name="l10n_ro_shipping_weights" />
-                    <group>
-                        <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
-                        <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
-                    </group>
+                    <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
+                    <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
                     <field
                         name="l10n_ro_shipping_weight_lines"
                         invisible="not l10n_ro_shipping_weights"


### PR DESCRIPTION
## Summary
- The `l10n_ro_shipping_weights` checkbox on the picking (and batch) form's eTransport tab rendered with no visible label.
- Root cause: the `weights` `<group>` nested a plain `<group>` inside itself (holding `total_net_weight`/`total_gross_weight`). Odoo's form compiler renders a `<group>` as an "OuterGroup" (group-of-groups layout) whenever any direct child is itself a `<group>`, and OuterGroup mode skips automatic label generation for every plain field in it — not just the nested ones.
- Removed the nested `<group>` in both `l10n_ro_etransport_enhancement/views/stock_picking_view.xml` and `l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml`; `total_net_weight`/`total_gross_weight` are now direct fields of `weights`, which renders as a normal InnerGroup with labels for all three fields.

## Test plan
- [ ] Open a delivery/receipt picking form, eTransport tab: confirm "Custom Shipping Weights" checkbox now shows its label, and toggling it still shows/hides the net/gross weight fields and the weight lines table.
- [ ] Open a picking batch form, eTransport tab: same check.