### PR TITLE
[FIX] l10n_ro_etransport_enhancement: greutateBruta=0 rejected by ANAF

### DIFF
--- a/l10n_ro_etransport_enhancement/README.rst
+++ b/l10n_ro_etransport_enhancement/README.rst
@@ -85,6 +85,22 @@ localizare pentru România dezvoltată de Terrabit.
 Changelog
 =========
 
+18.0.0.2.4 (2026-07-08)
+-----------------------
+
+- **Fixed ANAF rejection: "Attribute 'greutateBruta' must appear on
+  element 'bunuriTransportate'".** Same root cause as the ``cantitate``
+  fix above: the QWeb template renders
+  ``greutateNeta``/``greutateBruta`` via ``t-att-*``, which silently
+  drops a falsy (``0.0``) value from the XML. Unlike ``cantitate``, a
+  zero weight does not mean the line should be removed — it usually
+  means the product's ``weight`` field (or the shipping weight line) was
+  never filled in, while the goods are genuinely being transported.
+  ``_l10n_ro_edi_stock_get_template_data`` now falls back to the other
+  known weight (``greutateNeta`` for a zero ``greutateBruta``, or vice
+  versa) as an approximation, so a missing product weight no longer
+  breaks the whole submission.
+
 18.0.0.2.3 (2026-07-08)
 -----------------------
 

--- a/l10n_ro_etransport_enhancement/__manifest__.py
+++ b/l10n_ro_etransport_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eTransport Enhancement",
-    "version": "18.0.0.2.3",
+    "version": "18.0.0.2.4",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eTransport enhancement",

--- a/l10n_ro_etransport_enhancement/models/stock_picking.py
+++ b/l10n_ro_etransport_enhancement/models/stock_picking.py
@@ -195,6 +195,20 @@ class Picking(models.Model):
         for item in res["data"]["notificare"]["bunuriTransportate"][:]:
             if float_is_zero(item["cantitate"], precision_rounding=0.01):
                 res["data"]["notificare"]["bunuriTransportate"].remove(item)
+                continue
+            # ANAF requires both greutateNeta and greutateBruta on bunuriTransportate, and
+            # the QWeb template renders them via t-att-*, which silently drops a falsy (0.0)
+            # value from the XML. When the product/weight line has no weight recorded, one
+            # of the two can end up 0.0 while the other is known: fall back to the known one
+            # as an approximation rather than submitting an invalid document.
+            if float_is_zero(item["greutateBruta"], precision_rounding=0.01) and not float_is_zero(
+                item["greutateNeta"], precision_rounding=0.01
+            ):
+                item["greutateBruta"] = item["greutateNeta"]
+            elif float_is_zero(item["greutateNeta"], precision_rounding=0.01) and not float_is_zero(
+                item["greutateBruta"], precision_rounding=0.01
+            ):
+                item["greutateNeta"] = item["greutateBruta"]
         return res
 
     def action_l10n_ro_edi_stock_fetch_status(self):

--- a/l10n_ro_etransport_enhancement/readme/HISTORY.md
+++ b/l10n_ro_etransport_enhancement/readme/HISTORY.md
@@ -1,3 +1,16 @@
+## 18.0.0.2.4 (2026-07-08)
+
+- **Fixed ANAF rejection: "Attribute 'greutateBruta' must appear on element
+  'bunuriTransportate'".** Same root cause as the `cantitate` fix above: the
+  QWeb template renders `greutateNeta`/`greutateBruta` via `t-att-*`, which
+  silently drops a falsy (`0.0`) value from the XML. Unlike `cantitate`, a
+  zero weight does not mean the line should be removed — it usually means the
+  product's `weight` field (or the shipping weight line) was never filled in,
+  while the goods are genuinely being transported. `_l10n_ro_edi_stock_get_template_data`
+  now falls back to the other known weight (`greutateNeta` for a zero
+  `greutateBruta`, or vice versa) as an approximation, so a missing product
+  weight no longer breaks the whole submission.
+
 ## 18.0.0.2.3 (2026-07-08)
 
 - **Fixed ANAF rejection: "Attribute 'cantitate' must appear on element

--- a/l10n_ro_etransport_enhancement/static/description/index.html
+++ b/l10n_ro_etransport_enhancement/static/description/index.html
@@ -435,6 +435,23 @@ localizare pentru România dezvoltată de Terrabit.</p>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>18.0.0.2.4 (2026-07-08)</h1>
+<ul class="simple">
+<li><strong>Fixed ANAF rejection: “Attribute ‘greutateBruta’ must appear on
+element ‘bunuriTransportate’”.</strong> Same root cause as the <tt class="docutils literal">cantitate</tt>
+fix above: the QWeb template renders
+<tt class="docutils literal">greutateNeta</tt>/<tt class="docutils literal">greutateBruta</tt> via <tt class="docutils literal"><span class="pre">t-att-*</span></tt>, which silently
+drops a falsy (<tt class="docutils literal">0.0</tt>) value from the XML. Unlike <tt class="docutils literal">cantitate</tt>, a
+zero weight does not mean the line should be removed — it usually
+means the product’s <tt class="docutils literal">weight</tt> field (or the shipping weight line) was
+never filled in, while the goods are genuinely being transported.
+<tt class="docutils literal">_l10n_ro_edi_stock_get_template_data</tt> now falls back to the other
+known weight (<tt class="docutils literal">greutateNeta</tt> for a zero <tt class="docutils literal">greutateBruta</tt>, or vice
+versa) as an approximation, so a missing product weight no longer
+breaks the whole submission.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>18.0.0.2.3 (2026-07-08)</h1>
 <ul class="simple">
 <li><strong>Fixed ANAF rejection: “Attribute ‘cantitate’ must appear on element


### PR DESCRIPTION
## Summary
- ANAF rejects eTransport submissions with `Attribute 'greutateBruta' must appear on element 'bunuriTransportate'` when a line ends up with gross weight 0.0 (e.g. the product's `weight` field was never filled in, or the shipping weight line has no gross weight set).
- Same root cause as the earlier `cantitate` fix (#459): the QWeb template renders `greutateNeta`/`greutateBruta` via `t-att-*`, and Odoo's QWeb compiler silently drops any falsy (`0.0`) value from the generated XML, so the attribute vanishes and ANAF's XSD validation rejects the whole document.
- Unlike a zero `cantitate`, a zero weight does **not** mean the goods weren't transported — dropping the line would hide real cargo. `_l10n_ro_edi_stock_get_template_data` now falls back to the other known weight (`greutateNeta` for a zero `greutateBruta`, or vice versa) as an approximation, applied once at the end after all overrides (order-value/shipping-weight-line lookups) have run.

## Test plan
- [ ] Generate an eTransport document for a picking whose product has no `weight` set (or a shipping weight line with `gross_weight = 0`) and confirm `greutateBruta` is filled with the `greutateNeta` value instead of 0.
- [ ] Generate a normal document (both weights non-zero) and confirm output is unchanged.
- [ ] Submit to ANAF sandbox/test environment and confirm no more `greutateBruta` XSD rejection.