### PR TITLE
[IMP] l10n_ro_etransport(_batch)_enhancement: warn when weight lines …

### DIFF
--- a/l10n_ro_etransport_batch_enhancement/__manifest__.py
+++ b/l10n_ro_etransport_batch_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eTransport Batch Enhancement",
-    "version": "18.0.0.1.1",
+    "version": "18.0.0.1.2",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eTransport Batch Enhancement",

--- a/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
+++ b/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
@@ -22,6 +22,7 @@ class StockPickingBatch(models.Model):
     )
     total_net_weight = fields.Float()
     total_gross_weight = fields.Float()
+    l10n_ro_shipping_weight_lines_warning = fields.Char(compute="_compute_l10n_ro_shipping_weight_lines_warning")
     l10n_ro_transport_partner_id = fields.Many2one(
         "res.partner",
         string="Transport Partner",
@@ -40,6 +41,23 @@ class StockPickingBatch(models.Model):
         for batch in self:
             for picking in batch.picking_ids:
                 picking.l10n_ro_transport_partner_id = batch.l10n_ro_transport_partner_id
+
+    @api.depends("l10n_ro_shipping_weights", "l10n_ro_shipping_weight_lines.move_id", "move_ids.quantity")
+    def _compute_l10n_ro_shipping_weight_lines_warning(self):
+        for batch in self:
+            if not batch.l10n_ro_shipping_weights:
+                batch.l10n_ro_shipping_weight_lines_warning = False
+                continue
+            expected = batch.move_ids.filtered(lambda m: m.quantity > 0)
+            missing = expected - batch.l10n_ro_shipping_weight_lines.move_id
+            if missing:
+                batch.l10n_ro_shipping_weight_lines_warning = _(
+                    "%(missing)s din %(total)s mișcări nu au linie de greutate calculată. Apăsați „Get lines”.",
+                    missing=len(missing),
+                    total=len(expected),
+                )
+            else:
+                batch.l10n_ro_shipping_weight_lines_warning = False
 
     def _compute_l10n_ro_edi_carrier_id(self):
         for batch in self:

--- a/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
+++ b/l10n_ro_etransport_batch_enhancement/models/stock_picking_batch.py
@@ -42,13 +42,13 @@ class StockPickingBatch(models.Model):
             for picking in batch.picking_ids:
                 picking.l10n_ro_transport_partner_id = batch.l10n_ro_transport_partner_id
 
-    @api.depends("l10n_ro_shipping_weights", "l10n_ro_shipping_weight_lines.move_id", "move_ids.quantity")
+    @api.depends("l10n_ro_shipping_weights", "l10n_ro_shipping_weight_lines.move_id", "picking_ids.move_ids.quantity")
     def _compute_l10n_ro_shipping_weight_lines_warning(self):
         for batch in self:
             if not batch.l10n_ro_shipping_weights:
                 batch.l10n_ro_shipping_weight_lines_warning = False
                 continue
-            expected = batch.move_ids.filtered(lambda m: m.quantity > 0)
+            expected = batch.picking_ids.move_ids.filtered(lambda m: m.quantity > 0)
             missing = expected - batch.l10n_ro_shipping_weight_lines.move_id
             if missing:
                 batch.l10n_ro_shipping_weight_lines_warning = _(

--- a/l10n_ro_etransport_batch_enhancement/readme/USAGE.md
+++ b/l10n_ro_etransport_batch_enhancement/readme/USAGE.md
@@ -1,0 +1,10 @@
+1. Open a transfer batch (*Inventory > Batch Transfers*, model `stock.picking.batch`).
+2. On the batch form, tick **e-Transport Required** if it isn't already set from the individual pickings. Two fields appear:
+   - **Carrier** (`delivery.carrier`): set once at batch level and it is propagated to every picking in the batch.
+   - **Transport Partner**: the carrier/transporter company reported to ANAF; also propagated to all component pickings.
+3. On the *e-Transport* tab, enable **Shipping weights** to manage weights at batch level:
+   - Click **Get lines** to pull in the transfer lines (product moves) from all pickings in the batch.
+   - Adjust net/gross weight per line if needed, then click **Distribute weights** to spread the batch's total net/gross weight proportionally across all lines.
+   - If a stock move gets reserved *after* the lines were generated (e.g. quantity was 0 when you clicked **Get lines**), it stays without a weight line. A red warning above the list tells you how many moves are missing a line so you can click **Get lines** again before sending.
+4. When the batch's e-Transport document is validated and sent to ANAF, the transport partner set on the batch is used automatically instead of requiring it on each picking.
+5. The batch delivery report (from `l10n_ro_stock_picking_batch_report`) now prints the ANAF **UIT** number once the e-Transport document is validated.

--- a/l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml
+++ b/l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml
@@ -17,11 +17,7 @@
                         <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
                         <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
                     </group>
-                    <div
-                        class="alert alert-danger"
-                        role="alert"
-                        invisible="not l10n_ro_shipping_weight_lines_warning"
-                    >
+                    <div class="alert alert-danger" role="alert" invisible="not l10n_ro_shipping_weight_lines_warning">
                         <field name="l10n_ro_shipping_weight_lines_warning" nolabel="1" />
                     </div>
                     <field

--- a/l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml
+++ b/l10n_ro_etransport_batch_enhancement/views/stock_picking_batch_view.xml
@@ -17,6 +17,13 @@
                         <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
                         <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
                     </group>
+                    <div
+                        class="alert alert-danger"
+                        role="alert"
+                        invisible="not l10n_ro_shipping_weight_lines_warning"
+                    >
+                        <field name="l10n_ro_shipping_weight_lines_warning" nolabel="1" />
+                    </div>
                     <field
                         name="l10n_ro_shipping_weight_lines"
                         invisible="not l10n_ro_shipping_weights"

--- a/l10n_ro_etransport_enhancement/__manifest__.py
+++ b/l10n_ro_etransport_enhancement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "eTransport Enhancement",
-    "version": "18.0.0.2.4",
+    "version": "18.0.0.2.5",
     "author": "Terrabit, Dorin Hongu, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "summary": "eTransport enhancement",

--- a/l10n_ro_etransport_enhancement/models/stock_picking.py
+++ b/l10n_ro_etransport_enhancement/models/stock_picking.py
@@ -22,6 +22,24 @@ class Picking(models.Model):
     total_net_weight = fields.Float()
     total_gross_weight = fields.Float()
     l10n_ro_transport_partner_id = fields.Many2one("res.partner", string="Transport Partner")
+    l10n_ro_shipping_weight_lines_warning = fields.Char(compute="_compute_l10n_ro_shipping_weight_lines_warning")
+
+    @api.depends("l10n_ro_shipping_weights", "l10n_ro_shipping_weight_lines.move_id", "move_ids.quantity")
+    def _compute_l10n_ro_shipping_weight_lines_warning(self):
+        for picking in self:
+            if not picking.l10n_ro_shipping_weights:
+                picking.l10n_ro_shipping_weight_lines_warning = False
+                continue
+            expected = picking.move_ids.filtered(lambda m: m.quantity > 0)
+            missing = expected - picking.l10n_ro_shipping_weight_lines.move_id
+            if missing:
+                picking.l10n_ro_shipping_weight_lines_warning = _(
+                    "%(missing)s din %(total)s mișcări nu au linie de greutate calculată. Apăsați „Get lines”.",
+                    missing=len(missing),
+                    total=len(expected),
+                )
+            else:
+                picking.l10n_ro_shipping_weight_lines_warning = False
 
     @api.onchange("carrier_id")
     def _onchange_carrier_id(self):

--- a/l10n_ro_etransport_enhancement/readme/USAGE.md
+++ b/l10n_ro_etransport_enhancement/readme/USAGE.md
@@ -1,0 +1,9 @@
+1. Go to *Inventory > Configuration > Settings*, section **UIT**:
+   - **Get UIT prices from sale/purchase orders**: when enabled, the e-Transport document pulls the goods' declared value from the linked sale/purchase order instead of the stock valuation.
+   - **Get only validated quantity from the picking instead of picking quantity**: shown only when the above is enabled; use it to report the actually validated (done) quantity to ANAF rather than the demanded quantity.
+2. On a stock picking (*Inventory > Transfers*), next to the carrier field you can now also fill in a **Transport Partner** even if no delivery **Carrier** is set — the picking can be validated for e-Transport with either one filled in, not both.
+3. On the *e-Transport* tab of the picking, enable **Shipping weights** to manage weights at line level:
+   - Click **Get lines** to populate the weight lines from the picking's stock moves.
+   - Edit net/gross weight per line, or click **Distribute weights** to spread a total net/gross weight proportionally across all lines.
+   - If a stock move gets reserved *after* the lines were generated (e.g. quantity was 0 when you clicked **Get lines**), it stays without a weight line. A red warning above the list tells you how many moves are missing a line so you can click **Get lines** again before sending.
+4. Validate and send the e-Transport document as usual (via `l10n_ro_edi_stock`); the corrected quantities/weights and the manual transport partner are used automatically when building the ANAF submission, avoiding rejections for missing `cantitate`/`greutateBruta` attributes on zero-quantity or zero-weight lines.

--- a/l10n_ro_etransport_enhancement/views/stock_picking_view.xml
+++ b/l10n_ro_etransport_enhancement/views/stock_picking_view.xml
@@ -16,6 +16,13 @@
                         <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
                         <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
                     </group>
+                    <div
+                        class="alert alert-danger"
+                        role="alert"
+                        invisible="not l10n_ro_shipping_weight_lines_warning"
+                    >
+                        <field name="l10n_ro_shipping_weight_lines_warning" nolabel="1" />
+                    </div>
                     <field
                         name="l10n_ro_shipping_weight_lines"
                         invisible="not l10n_ro_shipping_weights"

--- a/l10n_ro_etransport_enhancement/views/stock_picking_view.xml
+++ b/l10n_ro_etransport_enhancement/views/stock_picking_view.xml
@@ -16,11 +16,7 @@
                         <field name="total_net_weight" invisible="not l10n_ro_shipping_weights" />
                         <field name="total_gross_weight" invisible="not l10n_ro_shipping_weights" />
                     </group>
-                    <div
-                        class="alert alert-danger"
-                        role="alert"
-                        invisible="not l10n_ro_shipping_weight_lines_warning"
-                    >
+                    <div class="alert alert-danger" role="alert" invisible="not l10n_ro_shipping_weight_lines_warning">
                         <field name="l10n_ro_shipping_weight_lines_warning" nolabel="1" />
                     </div>
                     <field


### PR DESCRIPTION
…miss moves

l10n_ro_compute_weight_lines() only creates a weight line for moves with quantity > 0 at the time it runs. If a move gets reserved afterwards (e.g. stock wasn't fully assigned yet when "Get lines" was clicked), it silently stays without a weight line - and if the product's own weight is also 0 at that point, both greutateNeta and greutateBruta end up 0 with nothing for the existing fallback (65d3548b) to fall back to, so ANAF rejects the document with a missing greutateBruta attribute.

Add a computed warning shown as a red banner above the weight lines list, on both the picking and the batch form, so the gap is visible before sending rather than after an ANAF rejection.