### PR TITLE
Fix AttributeError: stock.move has no scheduled_date in eTransport

### DIFF
--- a/l10n_ro_etransport_enhancement/models/stock_picking.py
+++ b/l10n_ro_etransport_enhancement/models/stock_picking.py
@@ -91,14 +91,20 @@ class Picking(models.Model):
                 )
                 if move.purchase_line_id.currency_id != move.picking_id.company_id.currency_id:
                     price = move.purchase_line_id.currency_id._convert(
-                        price, move.picking_id.company_id.currency_id, move.picking_id.company_id, move.scheduled_date
+                        price,
+                        move.picking_id.company_id.currency_id,
+                        move.picking_id.company_id,
+                        move.picking_id.scheduled_date,
                     )
                 return price
             elif direction == "outgoing" and move.sale_line_id:
                 price = move.sale_line_id.price_reduce_taxexcl
                 if move.sale_line_id.currency_id != move.picking_id.company_id.currency_id:
                     price = move.sale_line_id.currency_id._convert(
-                        price, move.picking_id.company_id.currency_id, move.picking_id.company_id, move.scheduled_date
+                        price,
+                        move.picking_id.company_id.currency_id,
+                        move.picking_id.company_id,
+                        move.picking_id.scheduled_date,
                     )
                 return price
             return 0.00


### PR DESCRIPTION
## Summary
- `l10n_ro_etransport_enhancement/models/stock_picking.py` folosea `move.scheduled_date` la conversia valutară a prețului pentru transportul eTransport, dar `stock.move` nu are acest câmp (doar `stock.picking` îl are), ceea ce dădea `AttributeError` la trimiterea documentului eTransport (raportat pe valshop.ro).
- Folosește `move.picking_id.scheduled_date` în ambele locuri (achiziție și vânzare).

## Test plan
- [ ] Instalare/actualizare modul pe o bază de test cu tranzacție intracomunitară (valută diferită de RON) pe un `stock.picking` cu `l10n_ro_etransport_get_order_value` activ
- [ ] Trimitere document eTransport și verificare că nu mai apare `AttributeError`