### PR TITLE
[FIX] l10n_ro_stock_picking_report: ZeroDivisionError on internal transfer report

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ addon | version | maintainers | summary
 [l10n_ro_partner_create_by_vat_openapi](l10n_ro_partner_create_by_vat_openapi/) | 19.0.1.0.2 |  | Romania - Partner Create by VAT from OpenAPI
 [l10n_ro_sale_order_report](l10n_ro_sale_order_report/) | 19.0.1.0.4 |  | Formular Factura Proformae
 [l10n_ro_stock_account_enhancement](l10n_ro_stock_account_enhancement/) | 19.0.0.0.0 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | Romania - Stock Accounting Enhancement
-[l10n_ro_stock_picking_report](l10n_ro_stock_picking_report/) | 19.0.1.2.7 |  | Rapoarte: NIR, aviz, bon consum
+[l10n_ro_stock_picking_report](l10n_ro_stock_picking_report/) | 19.0.1.3.1 |  | Rapoarte: NIR, aviz, bon consum
 [l10n_ro_stock_picking_report_product_expiry](l10n_ro_stock_picking_report_product_expiry/) | 19.0.1.0.1 |  | Adds product expiry date to picking reports
 [l10n_ro_stock_report](l10n_ro_stock_report/) | 19.0.2.0.0 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> <a href='https://github.com/feketemihai'><img src='https://github.com/feketemihai.png' width='32' height='32' style='border-radius:50%;' alt='feketemihai'/></a> | Stock Report (Fișă Magazie)
 [l10n_ro_zip](l10n_ro_zip/) | 19.0.0.0.0 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | Romania - Coduri Postale

--- a/l10n_ro_stock_picking_report/README.rst
+++ b/l10n_ro_stock_picking_report/README.rst
@@ -26,6 +26,12 @@ Romania - Terrabit - Picking Reports
    - Referinta din comanda de achizitie este copiata in NIR si factura
    - Option in settings (Romania) for printing taxes on reception
    - Option in settings (Romania) for printing banks on reports
+   - Livrarile marcate ca aviz (``l10n_ro_notice``) se tiparesc cu
+     titlul "Aviz de insotire a marfii" (14-3-6A); livrarile obisnuite
+     raman "Livrare"
+   - Pe livrarile fara comanda de vanzare (aviz, custodie, consignatie),
+     raportul "Delivery with price" preia pretul din lista de preturi a
+     partenerului sau pretul de lista al produsului
 
 **Table of contents**
 
@@ -34,6 +40,17 @@ Romania - Terrabit - Picking Reports
 
 Changelog
 =========
+
+19.0.1.3.1
+----------
+
+- **Fix:** internal transfer report no longer crashes with
+  ``ZeroDivisionError`` when a move has only the done quantity filled in
+  (``quantity``) and no demand (``product_uom_qty``), which leaves
+  ``product_qty`` at 0. The unit price now falls back to ``quantity``
+  and the division is skipped entirely when both quantities are 0. The
+  previous ``or 1`` fallback applied to the division result, not the
+  denominator, so it never protected against this case.
 
 19.0.1.2.10
 -----------

--- a/l10n_ro_stock_picking_report/__manifest__.py
+++ b/l10n_ro_stock_picking_report/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Romania - Terrabit - Picking Reports",
     "summary": "Rapoarte: NIR, aviz, bon consum",
     "license": "AGPL-3",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.3.1",
     "development_status": "Mature",
     "author": "Dorin Hongu,Terrabit,Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",

--- a/l10n_ro_stock_picking_report/readme/HISTORY.md
+++ b/l10n_ro_stock_picking_report/readme/HISTORY.md
@@ -1,3 +1,13 @@
+## 19.0.1.3.1
+
+- **Fix:** internal transfer report no longer crashes with
+  `ZeroDivisionError` when a move has only the done quantity filled in
+  (`quantity`) and no demand (`product_uom_qty`), which leaves
+  `product_qty` at 0. The unit price now falls back to `quantity` and the
+  division is skipped entirely when both quantities are 0. The previous
+  `or 1` fallback applied to the division result, not the denominator, so
+  it never protected against this case.
+
 ## 19.0.1.2.10
 
 - **Fix:** reception report no longer crashes on Odoo 19. `stock.picking` lost

--- a/l10n_ro_stock_picking_report/report/picking.py
+++ b/l10n_ro_stock_picking_report/report/picking.py
@@ -210,7 +210,10 @@ class ReportPickingReception(models.AbstractModel):
 
             # obtinere valoare pentru transferuri interne
             if not res["price"] and move.picking_id.picking_type_code == "internal":
-                res["price"] = move.value / move.product_qty or 1
+                # product_qty poate fi 0 cand e completata doar cantitatea efectuata (quantity)
+                qty = move.product_qty or move.quantity
+                if qty:
+                    res["price"] = move.value / qty or 1
 
             taxes_ids = move.product_id.supplier_taxes_id.filtered(lambda r: r.company_id == move.company_id)
             taxes = taxes_ids.compute_all(

--- a/l10n_ro_stock_picking_report/static/description/index.html
+++ b/l10n_ro_stock_picking_report/static/description/index.html
@@ -376,20 +376,27 @@ ul.auto-toc {
 <li>Referinta din comanda de achizitie este copiata in NIR si factura</li>
 <li>Option in settings (Romania) for printing taxes on reception</li>
 <li>Option in settings (Romania) for printing banks on reports</li>
+<li>Livrarile marcate ca aviz (<tt class="docutils literal">l10n_ro_notice</tt>) se tiparesc cu
+titlul “Aviz de insotire a marfii” (14-3-6A); livrarile obisnuite
+raman “Livrare”</li>
+<li>Pe livrarile fara comanda de vanzare (aviz, custodie, consignatie),
+raportul “Delivery with price” preia pretul din lista de preturi a
+partenerului sau pretul de lista al produsului</li>
 </ul>
 </blockquote>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#changelog" id="toc-entry-1">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-2">19.0.1.2.10</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-2">19.0.1.3.1</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-3">19.0.1.2.10</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -397,7 +404,19 @@ ul.auto-toc {
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-1">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-2">19.0.1.2.10</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-2">19.0.1.3.1</a></h2>
+<ul class="simple">
+<li><strong>Fix:</strong> internal transfer report no longer crashes with
+<tt class="docutils literal">ZeroDivisionError</tt> when a move has only the done quantity filled in
+(<tt class="docutils literal">quantity</tt>) and no demand (<tt class="docutils literal">product_uom_qty</tt>), which leaves
+<tt class="docutils literal">product_qty</tt> at 0. The unit price now falls back to <tt class="docutils literal">quantity</tt>
+and the division is skipped entirely when both quantities are 0. The
+previous <tt class="docutils literal">or 1</tt> fallback applied to the division result, not the
+denominator, so it never protected against this case.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h2><a class="toc-backref" href="#toc-entry-3">19.0.1.2.10</a></h2>
 <ul class="simple">
 <li><strong>Fix:</strong> reception report no longer crashes on Odoo 19.
 <tt class="docutils literal">stock.picking</tt> lost the <tt class="docutils literal">group_id</tt> field (the procurement group
@@ -412,22 +431,22 @@ both <tt class="docutils literal">stock.picking</tt> (<tt class="docutils litera
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.
 In case of trouble, please check there if your issue has already been reported.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Dorin Hongu</li>
 <li>Terrabit</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.nexterp.ro">NextERP Romania</a>:<ul>
 <li>Fekete Mihai &lt;<a class="reference external" href="mailto:feketemihai&#64;nexterp.ro">feketemihai&#64;nexterp.ro</a>&gt;</li>
@@ -443,7 +462,7 @@ In case of trouble, please check there if your issue has already been reported.<
 technical issues.</p>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/dhongu/l10n-romania/tree/19.0/l10n_ro_stock_picking_report">dhongu/l10n-romania</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>


### PR DESCRIPTION
# Fix: ZeroDivisionError la raportul de transfer intern

## Context / de ce

Pe staging-ul unui client (Odoo 19, `inedit-ventures-terrabit-staging`), tipărirea
raportului de transfer intern (`report_internal_transfer`) crăpa cu:

```
File ".../l10n_ro_stock_picking_report/report/picking.py", line 213, in _get_line
    res["price"] = move.value / move.product_qty or 1
ZeroDivisionError: float division by zero
```

Utilizatorul a completat pe mișcare doar cantitatea efectuată (`quantity`), fără
cantitatea cerută (`product_uom_qty`), deci `product_qty` (calculat din cerere) era 0.

În plus, fallback-ul existent `or 1` nu proteja împărțirea: din precedența
operatorilor, expresia se evaluează `(move.value / move.product_qty) or 1`, adică
`or 1` se aplică *rezultatului*, nu numitorului.

## Ce s-a schimbat

- `report/picking.py` (`_get_line`, ramura „transfer intern"): cantitatea folosită la
  calculul prețului unitar este acum `move.product_qty or move.quantity`, iar
  împărțirea se face doar dacă această cantitate e nenulă. Dacă ambele cantități sunt
  0, prețul rămâne `0.0` (valoarea de inițializare) în loc să crape raportul.
  Comportamentul existent (fallback la preț 1 când valoarea e 0) e păstrat.
- `__manifest__.py`: bump versiune `19.0.1.3.0` → `19.0.1.3.1`.
- `readme/HISTORY.md`: intrare de changelog pentru `19.0.1.3.1`; `README.rst` și
  `static/description/index.html` regenerate de `oca-gen-addon-readme`.
- `README.md` (rădăcină): actualizată doar linia modulului în tabelul de addons
  (restul tabelului are drift preexistent de la alte module și nu a fost atins).

## Testare

- `pre-commit` (ruff, ruff-format, pylint-odoo etc.) trece pe fișierele modificate.
- Notă: hook-ul `oca-gen-addon-readme` din `pre-commit run -a` pică pe un modul
  neatins de acest PR (`l10n_ro_efactura_enhancement` — stil de titluri inconsistent
  în fragmente), drift preexistent pe 19.0, în afara scope-ului acestui PR.

## Note / riscuri

- Cealaltă împărțire din același fișier (linia ~130, `value / move.quantity`) era
  deja protejată de `if move.quantity:` — neatinsă.
- Fără migrări de date, fără dependențe noi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)