### PR TITLE
[19.0][FIX] l10n_ro_invoice_report: KeyError get_pickings la preview layout document

### DIFF
--- a/l10n_ro_invoice_report/views/invoice_report.xml
+++ b/l10n_ro_invoice_report/views/invoice_report.xml
@@ -699,7 +699,9 @@
                 </div>
             </t>
 
-            <t t-set="pickings" t-value="get_pickings(o)"/>
+            <t t-if="get_pickings">
+                <t t-set="pickings" t-value="get_pickings(o)"/>
+            </t>
             <div t-if="pickings and not res_company.hide_pickings_in_invoice" name="pickings">
                 <t t-if="o.move_type == 'in_invoice'">
                     <strong>Receptions:</strong>


### PR DESCRIPTION
## Ce rezolvă

Preview-ul de layout document (Settings > Invoicing > Document Layout, sau print-preview dintr-o factură) rula cu KeyError:

```
KeyError: 'get_pickings'
Template: account.report_invoice_document_preview
Element: <div t-if="pickings and not res_company.hide_pickings_in_invoice" name="pickings"/>
```

`get_pickings` este injectat doar în `report.account.report_invoice._get_report_values()` (randarea reală a raportului PDF). Preview-ul de layout apelează `account.report_invoice_document_preview` direct prin `ir.ui.view._render_template()`, fără acest context, deci variabila nu există.

Un nume urmat imediat de `(` este compilat de QWeb strict ca `values['get_pickings']` (ca să dea eroare clară în loc de „NoneType is not callable”), deci lipsa cheii sparge tot ecranul de preview.

## Fix

`t-set="pickings" t-value="get_pickings(o)"` rulează acum doar dacă `get_pickings` există în context (`t-if="get_pickings"`, referință simplă = safe-getter în QWeb). Comportamentul la generarea reală a facturii (unde `get_pickings` e prezent) rămâne identic.

## Test plan

- [ ] Update modul `l10n_ro_invoice_report` pe o bază RO
- [ ] Deschide Settings > Invoicing > Configuration > Document Layout → preview-ul se afișează fără eroare
- [ ] Print/preview pe o factură reală cu recepții/livrări asociate → secțiunea "Deliveries/Receptions" tot apare corect