### PR TITLE
[19.0][UPD] l10n_ro_sale_order_report: portare setari din 18.0 + fix compatibilitate v19

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ addon | version | maintainers | summary
 [l10n_ro_message_spv_purchase](l10n_ro_message_spv_purchase/) | 19.0.0.0.1 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | Add SPV message on purchase orders for Romania
 [l10n_ro_partner_create_by_vat_button](l10n_ro_partner_create_by_vat_button/) | 19.0.1.1.7 |  | Partner Create by VAT Button
 [l10n_ro_partner_create_by_vat_openapi](l10n_ro_partner_create_by_vat_openapi/) | 19.0.1.0.2 |  | Romania - Partner Create by VAT from OpenAPI
-[l10n_ro_sale_order_report](l10n_ro_sale_order_report/) | 19.0.1.0.4 |  | Formular Factura Proformae
+[l10n_ro_sale_order_report](l10n_ro_sale_order_report/) | 19.0.1.0.6 |  | Formular Factura Proformae
 [l10n_ro_stock_account_enhancement](l10n_ro_stock_account_enhancement/) | 19.0.0.0.0 | <a href='https://github.com/dhongu'><img src='https://github.com/dhongu.png' width='32' height='32' style='border-radius:50%;' alt='dhongu'/></a> | Romania - Stock Accounting Enhancement
 [l10n_ro_stock_picking_report](l10n_ro_stock_picking_report/) | 19.0.1.3.1 |  | Rapoarte: NIR, aviz, bon consum
 [l10n_ro_stock_picking_report_product_expiry](l10n_ro_stock_picking_report_product_expiry/) | 19.0.1.0.1 |  | Adds product expiry date to picking reports

--- a/l10n_ro_sale_order_report/__manifest__.py
+++ b/l10n_ro_sale_order_report/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Terrabit Sale Order Report",
     "summary": "Formular Factura Proformae",
-    "version": "19.0.1.0.5",
+    "version": "19.0.1.0.6",
     "author": "Terrabit, Dorin Hongu, Dan Stoica, Odoo Community Association (OCA)",
     "website": "https://www.terrabit.ro",
     "category": "Localization",

--- a/l10n_ro_sale_order_report/models/res_config.py
+++ b/l10n_ro_sale_order_report/models/res_config.py
@@ -15,6 +15,21 @@ class ResCompany(models.Model):
     exclude_product_name_from_description_offer = fields.Boolean(
         string="Exclude product name from description", help="Exclude product name from sale order line description"
     )
+    make_description_smaller = fields.Boolean(
+        string="Make description smaller",
+        default=False,
+        help="Make the description smaller on the sale order line if the product name is not excluded",
+    )
+    show_total_amount_with_taxes_on_so = fields.Boolean(
+        string="Show Total Amount with Taxes on SO",
+        help="Show Total Amount with Taxes on Sale Order Report",
+        default=False,
+    )
+    show_lead_time = fields.Boolean(
+        string="Show Lead Time on SO",
+        help="Show Lead Time on Sale Order Report",
+        default=False,
+    )
 
 
 class ResConfigSettings(models.TransientModel):
@@ -37,4 +52,22 @@ class ResConfigSettings(models.TransientModel):
         string="Exclude product name from description",
         readonly=False,
         help="Exclude product name from sale order line description",
+    )
+    make_description_smaller = fields.Boolean(
+        related="company_id.make_description_smaller",
+        string="Make description smaller",
+        readonly=False,
+        help="Make the description smaller on the sale order line if the product name is not excluded",
+    )
+    show_total_amount_with_taxes_on_so = fields.Boolean(
+        related="company_id.show_total_amount_with_taxes_on_so",
+        string="Show Total Amount with Taxes on SO",
+        readonly=False,
+        help="Show Total Amount with Taxes on Sale Order Report",
+    )
+    show_lead_time = fields.Boolean(
+        related="company_id.show_lead_time",
+        string="Show Lead Time on SO",
+        readonly=False,
+        help="Show Lead Time on Sale Order Report",
     )

--- a/l10n_ro_sale_order_report/views/res_config_view.xml
+++ b/l10n_ro_sale_order_report/views/res_config_view.xml
@@ -15,6 +15,15 @@
              <setting help="Exclude product name from sale order line description">
                     <field name="exclude_product_name_from_description_offer" />
                 </setting>
+                <setting help="Make the description smaller on the sale order line if the product name is not excluded">
+                    <field name="make_description_smaller" />
+                </setting>
+                <setting help="Show Total Amount with Taxes on Sale Order Report">
+                    <field name="show_total_amount_with_taxes_on_so" />
+                </setting>
+                <setting help="Show Lead Time on Sale Order Report">
+                    <field name="show_lead_time" />
+                </setting>
             </xpath>
         </field>
     </record>

--- a/l10n_ro_sale_order_report/views/sale_order.xml
+++ b/l10n_ro_sale_order_report/views/sale_order.xml
@@ -33,11 +33,21 @@
             </div>
         </xpath>
         <!--Poze produse si nr. crt-->
-        <xpath expr="//tbody/t" position="before">
-            <t t-set="nr_crt" t-value="1" />
-        </xpath>
-        <xpath expr="//tbody//tr" position="inside">
-            <t t-set="nr_crt" t-value="nr_crt + 1" />
+         <xpath expr="//th[@name='th_discount']" position="after">
+                <th
+                t-if="res_company.show_lead_time and any(line.customer_lead for line in doc.order_line)"
+                name="th_terms"
+                class="text-end"
+            >Lead Time (days)</th>
+            </xpath>
+        <xpath expr="//td[@name='td_product_taxes']" position="before">
+            <td
+                t-if="res_company.show_lead_time and any(line.customer_lead for line in doc.order_line)"
+                name="td_terms"
+                class="text-end"
+            >
+                <span t-esc="round(line.customer_lead)" />
+            </td>
         </xpath>
         <xpath expr="//table/thead/tr/th" position="before">
             <t t-if="res_company.counter_on_sale_order">
@@ -50,7 +60,7 @@
         <td name="td_product_name" position="before">
              <t t-if="res_company.counter_on_sale_order">
                 <td name="td_number">
-                    <span t-esc="nr_crt" />
+                    <span t-esc="line_index + 1" />
                 </td>
              </t>
              <t t-if="res_company.include_image_line">
@@ -77,7 +87,17 @@
                         <span t-esc="line_name">Bacon Burger</span>
                     </t>
                     <t t-if="not res_company.exclude_product_name_from_description_offer">
-                        <span t-field="line.name">Bacon Burger</span>
+                        <t t-if="res_company.make_description_smaller">
+                            <span t-field="line.product_id.display_name">Bacon Burger</span>
+                            <br />
+                            <t t-set="line_name" t-value="line.name" />
+                            <t t-set="product_name" t-value="line.product_id.display_name" />
+                            <t t-set="line_name" t-value="line_name.replace(product_name, '',1)" />
+                            <span t-esc="line_name" style="font-size: 85%;">Bacon Burger</span>
+                        </t>
+                        <t t-else="not res_company.make_description_smaller">
+                            <span t-field="line.name">Bacon Burger</span>
+                        </t>
                     </t>
                 </t>
 
@@ -103,6 +123,37 @@
                 </t>
             </t>
         </p>
+
+        <xpath expr="//th[@name='th_subtotal']/span" position="after">
+            <t t-if="res_company.show_total_amount_with_taxes_on_so">
+                <br />
+                <span>(without taxes)</span>
+            </t>
+        </xpath>
+
+        <xpath expr="//th[@name='th_subtotal']" position="after">
+            <th name="th_price_taxes" class="text-end" t-if="res_company.show_total_amount_with_taxes_on_so">
+                <span>Taxes Values</span>
+            </th>
+            <th name="th_total_amount" class="text-end" t-if="res_company.show_total_amount_with_taxes_on_so">
+                <span>Total amount</span>
+                <br />
+                <span>(with taxes)</span>
+            </th>
+        </xpath>
+
+        <xpath expr="//td[@name='td_product_subtotal']" position="after">
+            <t t-if="res_company.show_total_amount_with_taxes_on_so">
+                <td name="td_price_taxes" class="text-end">
+                    <t t-set="price_taxes" t-value="(line.price_total - line.price_subtotal )" />
+                    <span id="price_taxes" t-esc="price_taxes" t-options='{"widget": "float", "precision": 2}' />
+                </td>
+                <td class="text-end" id="price_total">
+                    <t t-set="price_total" t-value="line.price_total" />
+                    <span id="price_total" t-esc="price_total" t-options='{"widget": "float", "precision": 2}' />
+                </td>
+            </t>
+        </xpath>
     </template>
 
 
@@ -190,6 +241,26 @@
                             <th name="th_subtotal" class="text-end">
                                 <t groups="account.group_show_line_subtotals_tax_excluded">Amount</t>
                                 <t groups="account.group_show_line_subtotals_tax_included">Total Price</t>
+                                <t t-if="res_company.show_total_amount_with_taxes_on_so">
+                                    <br />
+                                    <span>(without taxes)</span>
+                                </t>
+                            </th>
+                            <th
+                                name="th_price_taxes"
+                                class="text-end"
+                                t-if="res_company.show_total_amount_with_taxes_on_so"
+                            >
+                                <span>Taxes Values</span>
+                            </th>
+                            <th
+                                name="th_total_amount"
+                                class="text-end"
+                                t-if="res_company.show_total_amount_with_taxes_on_so"
+                            >
+                                <span>Total amount</span>
+                                <br />
+                                <span>(with taxes)</span>
                             </th>
                         </tr>
                     </thead>
@@ -234,6 +305,24 @@
                                     t-options="{'widget': 'monetary', 'display_currency': doc.pricelist_id.currency_id or doc.company_id.currency_id}"
                                 />
                             </td>
+                            <t t-if="res_company.show_total_amount_with_taxes_on_so">
+                                <td name="td_price_taxes" class="text-end">
+                                    <t t-set="price_taxes" t-value="doc.amount_tax * percent" />
+                                    <span
+                                        id="price_taxes"
+                                        t-esc="price_taxes"
+                                        t-options='{"widget": "float", "precision": 2}'
+                                    />
+                                </td>
+                                <td class="text-end" id="price_total">
+                                    <t t-set="price_total" t-value="doc.amount_total * percent" />
+                                    <span
+                                        id="price_total"
+                                        t-esc="price_total"
+                                        t-options='{"widget": "float", "precision": 2}'
+                                    />
+                                </td>
+                            </t>
                         </tr>
                         <tr name="order_details">
                             <td name="td_name_details" colspan="3" class="  o_price_total">
@@ -262,6 +351,10 @@
                             <td class="text-right o_price_total">
 
                             </td>
+                            <t t-if="res_company.show_total_amount_with_taxes_on_so">
+                                <td class="text-right o_price_total" />
+                                <td class="text-right o_price_total" />
+                            </t>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
## Context / de ce

Modulul `l10n_ro_sale_order_report` avea deja setările `counter_on_sale_order`, `include_image_line`
și `exclude_product_name_from_description_offer`, dar nu și restul opțiunilor echivalente din
vechiul `deltatech_sale_order_report` (18.0), care fusese dezinstalat/gutted în timpul migrării
18→19 în favoarea acestui modul. Portăm restul funcțiilor aici, direct, ca să nu existe doi
proprietari pentru același raport de vânzări.

## Ce s-a schimbat

- **`models/res_config.py`**: câmpuri noi pe `res.company` / `res.config.settings`:
  `make_description_smaller`, `show_total_amount_with_taxes_on_so`, `show_lead_time`.
- **`views/res_config_view.xml`**: toggle-urile corespunzătoare în Settings.
- **`views/sale_order.xml`**:
  - coloană opțională "Lead Time (days)" pe raport, condiționată de `show_lead_time`.
  - coloane opționale "Taxes Values" / "Total amount (with taxes)", condiționate de
    `show_total_amount_with_taxes_on_so`, atât pe raportul principal de comandă/ofertă cât și pe
    proformă.
  - descriere linie: font mai mic pentru textul suplimentar când `make_description_smaller` e activ.
  - **2 corecții de compatibilitate Odoo 19**: xpath-urile noi țintiseră `td_taxes`/`td_subtotal`,
    nume valabile doar pe raportul de factură (`account`), nu pe cel de vânzări — Odoo 19 a
    redenumit celulele rândului de produs cu prefixul `product_` (`td_product_taxes`,
    `td_product_subtotal`). Corectat, altfel modulul nu se instala (eroare "Element ... cannot be
    located").
  - **fix contor linii**: mecanismul vechi (`nr_crt`, set + increment prin xpath pe `//tbody//tr`)
    incrementa doar pe 2 din cele 4 tipuri de rând din template-ul de bază Odoo 19 (secțiune, combo)
    — pe rândurile normale de produs (99% din cazuri) rămânea blocat la "1". Înlocuit cu indexul de
    buclă automat oferit de QWeb (`line_index + 1`), corect indiferent de tipul rândului.

## Testare

Testat live, local (`odoo-bin shell` + `_render_qweb_pdf`), pe o comandă reală cu 6 linii, discount,
tax 21%, un produs cu imagine și un lead time setat:

- Upgrade modul: fără erori de view/xpath.
- Numerotare (`counter_on_sale_order`): `1, 2, 3, 4, 5, 6` (înainte de fix: `1, 1, 1, 1, 1, 1`).
- Sumă fără taxe / valoare taxe / total cu taxe: verificat matematic pe fiecare linie (ex.
  319 × 0,9 = 287,10 → +21% = 60,29 → total 347,39).
- Lead time: coloana apare corect cu valoarea setată pe linie.
- Excludere nume produs din descriere: confirmat, rămâne doar textul suplimentar.
- Descriere mai mică: confirmat în HTML (`style="font-size: 85%"`).
- Imagine produs: randată corect în coloana dedicată.

## Note / riscuri

- Modulul „geamăn" `deltatech_sale_order_report` (repo `terrabit`) rămâne marcat „Obsolete" și
  neschimbat — nu a fost atins, ca să nu apară conflict de view-uri/câmpuri (ambele inheritau
  `sale.report_saleorder_document` cu aceleași xpath-uri).
- `deltatech_sale_payment` rămâne comentat în `depends` (nefolosit direct de codul nou); afectează
  doar raportul de "proforma finală" existent deja, în afara scope-ului acestui PR.

Generated with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)